### PR TITLE
Avoid using PositionFirstComponent

### DIFF
--- a/gap/perlist.gi
+++ b/gap/perlist.gi
@@ -548,7 +548,7 @@ InstallMethod(Collected, "for a periodic list",
     local x, i, p;
     x := Collected(l![1]);
     for i in l![2] do
-        p := PositionFirstComponent(x,i);
+        p := PositionSorted(x,[i]);
         if p>Length(x) then
             AddSet(x,[i,infinity]);
         else

--- a/gap/vector.gi
+++ b/gap/vector.gi
@@ -427,7 +427,7 @@ ACTIVITYSPARSE@ := function(l,e,v,n,x,y)
     if n=0 then
         d := v*e!.output;
         if not IsZero(d) then
-            p := PositionFirstComponent(l,[x,y]);
+            p := PositionSorted(l,[[x,y]]);
             if IsBound(l[p]) and l[p][1]=[x,y] then
                 l[p][2] := l[p][2] + d;
             else


### PR DESCRIPTION
The operation in GAP unfortunately is buggy (it has three methods installed, which unfortunately return inconsistent results when invoked on the same input). Thus we would like to deprecate (and eventually remove) this function. This pull request replaces its use in your package.
