### PR TITLE
Fixed attribute error when calling WreathProduct

### DIFF
--- a/gap/group.gi
+++ b/gap/group.gi
@@ -3122,14 +3122,16 @@ BindGlobal("HOMOMORPHISMGERMPERMGROUP@", function(G,data,n)
 end);
 
 BindGlobal("HOMOMORPHISMGERMPCGROUP@", function(G,data,n)
-    local pcpP, pcpG, Q, pcpQ, l, i;
+    local pcpP, pcpG, Q, pcpQ, l, i, inv;
 
     l := Length(AlphabetOfFRSemigroup(G))^n;
     i := IsomorphismPcGroup(PermGroup(G,n));
     if i=fail then
         return HOMOMORPHISMGERMPERMGROUP@(G,data,n);
     fi;
-    Q := WreathProduct(data.group,Range(i),InverseGeneralMapping(i),l);
+    inv := InverseGeneralMapping(i);
+    IsMapping(inv); # make sure the attribute IsMapping is actually set
+    Q := WreathProduct(data.group,Range(i),inv,l);
     pcpP := Pcgs(Range(i));
     pcpG := Pcgs(data.group);
     pcpQ := Pcgs(Q);
@@ -3149,14 +3151,16 @@ BindGlobal("HOMOMORPHISMGERMPCGROUP@", function(G,data,n)
 end);
 
 BindGlobal("HOMOMORPHISMGERMPCPGROUP@", function(G,data,n)
-    local pcpP, pcpG, Q, pcpQ, l, i;
+    local pcpP, pcpG, Q, pcpQ, l, i, inv;
 
     l := Length(AlphabetOfFRSemigroup(G))^n;
     i := IsomorphismPcpGroup(PermGroup(G,n));
     if i=fail then
         return HOMOMORPHISMGERMPERMGROUP@(G,data,n);
     fi;
-    Q := WreathProduct(data.group,Range(i),InverseGeneralMapping(i),l);
+    inv := InverseGeneralMapping(i);
+    IsMapping(inv); # make sure the attribute IsMapping is actually set
+    Q := WreathProduct(data.group,Range(i),inv,l);
     pcpP := Pcp(Range(i));
     pcpG := Pcp(data.group);
     pcpQ := Collector(Q);


### PR DESCRIPTION
I tried to reproduce the [example session](https://www.gap-system.org/Manuals/pkg/fr-2.3.6/doc/chap2.html#X78DF4DE18260BD80) in chapter 2 of the FR documentation. The command

`K := NormalClosure(Bm,Group(c));`

produced 

> Error, no method found! For debugging hints type ?Recovery from NoMethodFound
> Error, no 1st choice method found for 'WreathProduct' on 4 arguments called from
> WreathProduct( data.group, Range( i ), InverseGeneralMapping( i ), l ) at /usr/lib/gap/pkg/fr-2.3.6/gap/group.gi:3159 called from
> HOMOMORPHISMGERMPCPGROUP@fr( G, data, i ) at /usr/lib/gap/pkg/fr-2.3.6/gap/group.gi:3249 called from
> func( C[i] ) at /usr/lib/gap/lib/coll.gi:746 called from
> List( [ 1 .. n ], function ( i )
>       return HOMOMORPHISMGERMPCPGROUP@fr( G, data, i );
>   end ) at /usr/lib/gap/pkg/fr-2.3.6/gap/group.gi:3249 called from
> d.pifunc( arg[1], d.level ) at /usr/lib/gap/pkg/fr-2.3.6/gap/group.gi:147 called from
> ...  at line 1 of *stdin*
> you can 'quit;' to quit to outer loop, or
> you can 'return;' to continue

It seems that `InverseGeneralMapping( i )` didn't have the attribute `IsMapping` set. The fix calls `IsMapping` explicitly before calling `WreathProduct`.