### PR TITLE
Use package name in lowercase in URLs

### DIFF
--- a/PackageInfo.g
+++ b/PackageInfo.g
@@ -36,15 +36,15 @@ CommunicatedBy := "Götz Pfeiffer (NUI Galway)",
 
 SourceRepository := rec(
     Type := "git",
-    URL := Concatenation( "https://github.com/gap-packages/", ~.PackageName ),
+    URL := Concatenation( "https://github.com/gap-packages/", LowercaseString(~.PackageName) ),
 ),
 IssueTrackerURL := Concatenation( ~.SourceRepository.URL, "/issues" ),
-PackageWWWHome  := Concatenation( "https://gap-packages.github.io/", ~.PackageName ),
+PackageWWWHome  := Concatenation( "https://gap-packages.github.io/", LowercaseString(~.PackageName) ),
 README_URL      := Concatenation( ~.PackageWWWHome, "/README" ),
 PackageInfoURL  := Concatenation( ~.PackageWWWHome, "/PackageInfo.g" ),
 ArchiveURL      := Concatenation( ~.SourceRepository.URL,
                                  "/releases/download/v", ~.Version,
-                                 "/", ~.PackageName, "-", ~.Version ),
+                                 "/", LowercaseString(~.PackageName), "-", ~.Version ),
 ArchiveFormats := ".tar.gz",
 
 AbstractHTML := "The <span class=\"pkgname\">fr</span> package allows \


### PR DESCRIPTION
The name of the package is `FR`, but the name of the repository is `fr`. This results in URLs which can not be resolved. The proposed PR fixes this by using `LowercaseString`. Could you please make a new version of the package with this fix, otherwise it can not be picked up by the package update system. Thanks! 