### PR TITLE
Replace use of READ_COMMAND by READ_COMMAND_REAL

### DIFF
--- a/gap/group.gi
+++ b/gap/group.gi
@@ -1931,9 +1931,9 @@ InstallMethod(IsAmenableGroup, [IsFreeGroup],
 BindGlobal("STRING_ATOM2GAP@", function(s)
     local stream, result;
     stream := InputTextString(Concatenation(s,";"));
-    result := READ_COMMAND(stream,false);
+    result := READ_COMMAND_REAL(stream,false);
     CloseStream(stream);
-    return result;
+    return result[2];
 end);
 BindGlobal("STRING_WORD2GAP@", function(gens,s_generator,data,w)
     local s, f, i;

--- a/tst/kneading.g
+++ b/tst/kneading.g
@@ -19,8 +19,8 @@ test := function(s,t)
   ff := IsomorphismFpSubgroup(gg);
   AssignGeneratorVariables(Parent(Range(ff)));
   r := InputTextString(Concatenation(String(RelatorsOfFpGroup(Parent(Range(ff)))),";"));
-  ee := READ_COMMAND(r,false);
+  ee := READ_COMMAND_REAL(r,false);
   CloseStream(r);
-  return List(ee,x->PreImageElm(ff,x));
+  return List(ee,x->PreImageElm(ff,x[2]));
 end;
 


### PR DESCRIPTION
Both functions are undocumented GAP kernel functions. But the former one
will be removed in GAP 4.9.

Note: neither the old nor the new code performs any error checking. The
return value of READ_COMMAND_REAL is a list, whose first entry indicates
success (true) or failure (false), and the second entry is the return
value of the executed command (if there was any; otherwise, this entry
is not bound).