### PR TITLE
Get rid of data.holdername

### DIFF
--- a/gap/algebra.gi
+++ b/gap/algebra.gi
@@ -171,7 +171,7 @@ BindGlobal("STRINGSTOLMACHINE@", function(r,args,creator)
         else
             Add(output,One(r));
         fi;
-        temp := STRING_WORD2GAP@(gens,"GeneratorsOfAlgebraWithOne",data,temp[1])*One(data.holder);
+        temp := STRING_WORD2GAP@(gens,GeneratorsOfAlgebraWithOne(data.holder),temp[1])*One(data.holder);
         if not IsMatrix(temp) then
             Error("<arg> should have the form a=[[...]...]\n");
         fi;

--- a/gap/algebra.gi
+++ b/gap/algebra.gi
@@ -147,15 +147,8 @@ BindGlobal("TOTALDEGREE@", function(x)
 end);
 
 BindGlobal("STRINGSTOLMACHINE@", function(r,args,creator)
-    local temp, i, j, gens, transitions, output, data, Error;
+    local temp, i, j, gens, transitions, output, data;
 
-    Error := function(arg)
-        if IsBound(data) then
-            MakeReadWriteGlobal(data.holdername); Unbind(data.holdername);
-        fi;
-        CallFuncList(VALUE_GLOBAL("Error"),arg);
-    end;
-    
     if not IsRing(r) or not ForAll(args,IsString) then
         Error("<arg> should contain a ring and strings\n");
     fi;
@@ -167,13 +160,7 @@ BindGlobal("STRINGSTOLMACHINE@", function(r,args,creator)
     if Size(Set(gens)) <> Size(gens) then
         Error("all generators should have a distinct name\n");
     fi;
-    data := rec(holdername := RANDOMNAME@(),
-                holder := FreeAssociativeAlgebraWithOne(r,gens));
-    BindGlobal(data.holdername, data.holder);
-    Error := function(arg)
-        MakeReadWriteGlobal(data.holdername); Unbind(data.holdername);
-        CallFuncList(VALUE_GLOBAL("Error"),arg);
-    end;
+    data := rec(holder := FreeAssociativeAlgebraWithOne(r,gens));
 
     transitions := [];
     output := [];
@@ -204,7 +191,6 @@ BindGlobal("STRINGSTOLMACHINE@", function(r,args,creator)
         i := creator(r,List(GeneratorsOfFRMachine(i),x->FRElement(i,x)));
     fi;
     SetIsStateClosed(i,true);
-    MakeReadWriteGlobal(data.holdername); UnbindGlobal(data.holdername);
     return i;
 end);
 

--- a/gap/group.gi
+++ b/gap/group.gi
@@ -1942,15 +1942,16 @@ BindGlobal("STRING_ATOM2GAP@", function(s)
 end);
 BindGlobal("STRING_WORD2GAP@", function(gens,s_generator,data,w)
     local s, f, i;
-    s := "CallFuncList(function() local ";
+    s := "function(__the_argument__) local ";
     Append(s,gens[1]);
     for i in [2..Length(gens)] do Append(s,","); Append(s,gens[i]); od;
     Append(s,";");
     for i in [1..Length(gens)] do
-        Append(s,Concatenation(gens[i],":=",s_generator,"(",data.holdername,")[",String(i),"];"));
+        Append(s,Concatenation(gens[i],":=",s_generator,"(__the_argument__)[",String(i),"];"));
     od;
-    Append(s,"return "); Append(s,w); Append(s,";end,[])");
-    return STRING_ATOM2GAP@(s);
+    Append(s,"return "); Append(s,w); Append(s,";end");
+    f := EvalString(s);
+    return f(data.holder);
 end);
 BindGlobal("STRING_TRANSFORMATION2GAP@", function(t,data)
     local p;
@@ -1963,18 +1964,8 @@ BindGlobal("STRING_TRANSFORMATION2GAP@", function(t,data)
     data.degree := Maximum(data.degree,Length(p),MaximumList(p,0));
     return p;
 end);
-BindGlobal("RANDOMNAME@", function()
-    return List([1..10],i->Random("ABCDEFGHIJKLMNOPQRSTUVWXYZ"));
-end);
 BindGlobal("STRING_GROUP@", function(freecreator, s_generator, creator, args)
-    local temp, i, gens, states, action, mgens, data, Error, category, machine, group;
-    
-    Error := function(arg)
-        if IsBound(data) then
-            MakeReadWriteGlobal(data.holdername); Unbind(data.holdername);
-        fi;
-        CallFuncList(VALUE_GLOBAL("Error"),arg);
-    end;
+    local temp, i, gens, states, action, mgens, data, category, machine, group;
     
     if not IsString(args[Length(args)]) then
         category := Remove(args);
@@ -1995,9 +1986,7 @@ BindGlobal("STRING_GROUP@", function(freecreator, s_generator, creator, args)
     fi;
     states := [];
     action := [];
-    data := rec(degree := -1, holdername := RANDOMNAME@(),
-                holder := freecreator(gens));
-    BindGlobal(data.holdername, data.holder);
+    data := rec(degree := -1, holder := freecreator(gens));
 
     for temp in List(temp,x->x[2]) do
         temp := SplitString(temp,"<");
@@ -2069,7 +2058,6 @@ BindGlobal("STRING_GROUP@", function(freecreator, s_generator, creator, args)
     SetAlphabetOfFRSemigroup(group,AlphabetOfFRObject(machine));
     SetUnderlyingFRMachine(group,machine);
     SetIsStateClosed(group,true);
-    MakeReadWriteGlobal(data.holdername); UnbindGlobal(data.holdername);
     return group;
 end);
 


### PR DESCRIPTION
Temporarily setting and reseting global variables is a dangerous, and can be
avoided here. The result is also arguably easier to understand and debug.
