### PR TITLE
Call First instead of FirstOp

### DIFF
--- a/gap/perlist.gi
+++ b/gap/perlist.gi
@@ -628,9 +628,9 @@ InstallMethod(FirstOp, "for a periodic list",
         [IsPeriodicList,IsFunction],
         function(l,p)
     local x;
-    x := FirstOp(l![1],p);
+    x := First(l![1],p);
     if x=fail then
-        return FirstOp(l![2],p);
+        return First(l![2],p);
     else
         return x;
     fi;


### PR DESCRIPTION
This avoids method dispatch overhead. As a rule of thumb, one should
never call FirstOp directly.
