### PR TITLE
Use default banner string

### DIFF
--- a/PackageInfo.g
+++ b/PackageInfo.g
@@ -76,8 +76,6 @@ Dependencies := rec(
 
 AvailabilityTest := ReturnTrue,
                     
-BannerString := Concatenation("Loading ", ~.PackageName, " ", String( ~.Version ), " ...\n"),
-
 TestFile := "tst/testall.g",
 Keywords := ["functionally recursive group", "mealy machine", "automata group"]
 ));


### PR DESCRIPTION
So far the banner looks like this:

    Loading FR 2.4.7 ...

With this change, the default banner is used, which looks like this:

    ──────────────────────────────────────────────────────────────
    Loading  FR 2.4.7 (Functionally recursive and automata groups)
    by Laurent Bartholdi (http://www.uni-math.gwdg.de/laurent).
    Homepage: https://gap-packages.github.io/fr
    Report issues at https://github.com/gap-packages/fr/issues
    ──────────────────────────────────────────────────────────────
