### PR TITLE
doc: remove broken link to .zip archive

### DIFF
--- a/doc/fr.xml
+++ b/doc/fr.xml
@@ -39,7 +39,8 @@
   <URL>https://gap-packages.github.io/fr/</URL>.
   <P/>
   The latest release of the package may be downloaded as
-  <URL>https://github.com/gap-packages/fr/archive/&Version;.tar.gz</URL> (tar, gzipped) and <URL>https://github.com/gap-packages/fr/archive/&Version;.zip</URL> (zip). The latest repository version (possibly unstable) may be downloaded as <URL>https://github.com/gap-packages/fr/tarball/master</URL> (tar, gzipped),
+  <URL>https://github.com/gap-packages/fr/archive/&Version;.tar.gz</URL> (tar, gzipped).
+  The latest repository version (possibly unstable) may be downloaded as <URL>https://github.com/gap-packages/fr/tarball/master</URL> (tar, gzipped),
   <URL>https://github.com/gap-packages/fr.git</URL> (git repository), or
   explored at <URL>https://github.com/gap-packages/fr/tree/master/</URL>.
   </Alt>


### PR DESCRIPTION
There is no .zip archive created for fr releases, so don't link to it.

If you really want one, add `.zip` to `ArchiveFormats` in `PackageInfo.g`. (Oh, and make sure to really use the latest ReleaseTools, your last release was made with a rather old one, which e.g. did not catch a validation error for some reason... or maybe you were not even using ReleaseTools?)