### PR TITLE
makedoc.g: switch back to using AutoDoc

### DIFF
--- a/PackageInfo.g
+++ b/PackageInfo.g
@@ -54,7 +54,7 @@ AbstractHTML := "The <span class=\"pkgname\">fr</span> package allows \
 
 PackageDoc := rec(
   BookName  := "fr",
-  HTMLStart := "doc/chap0.html",
+  HTMLStart := "doc/chap0_mj.html",
   PDFFile   := "doc/manual.pdf",
   SixFile   := "doc/manual.six",
   LongTitle := "Functionally recursive and automata groups",

--- a/makedoc.g
+++ b/makedoc.g
@@ -1,14 +1,11 @@
-#if fail = LoadPackage("AutoDoc", ">= 2016.01.21") then
-#    Error("AutoDoc 2016.01.21 or newer is required");
-#fi;
-#AutoDoc(rec(gapdoc := rec(files:=["PackageInfo.g"])));
-
-MakeGAPDocDoc("doc","fr",
-  ["../gap/frmachine.gd","../gap/frelement.gd","../gap/mealy.gd",
-   "../gap/group.gd","../gap/vector.gd","../gap/algebra.gd",
-   "../gap/examples.gd","../gap/helpers.gd","../gap/perlist.gd","../gap/cp.gd",
-   "../PackageInfo.g"],"fr","../../..");
-CopyHTMLStyleFiles("doc");
-GAPDocManualLab("fr");
+if fail = LoadPackage("AutoDoc", ">= 2019.04.10") then
+    Error("AutoDoc 2019.04.10 or newer is required");
+fi;
+AutoDoc(rec(
+    gapdoc := rec(
+        main:="fr.xml",
+        files:=["PackageInfo.g"],
+    )
+));
 
 QUIT;


### PR DESCRIPTION
As a bonus, this enables MathJax versions of the manual

As it is, I am not sure why usage of AutoDoc was disabled by @laurentbartholdi in 0b78c55cc7b53cc315ad73a513d32121d46b6d1b in 2016 ? Did something not work right? What?