### PR TITLE
Use AutoDoc entities for version & date (with latest AutoDoc)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,6 +19,7 @@ doc/*.out
 doc/*.toc
 doc/*.js
 doc/*.css
+doc/_*.xml
 doc/manual.pdf
 doc/manual.six
 doc/manual.lab

--- a/PackageInfo.g
+++ b/PackageInfo.g
@@ -54,7 +54,7 @@ AbstractHTML := "The <span class=\"pkgname\">fr</span> package allows \
 
 PackageDoc := rec(
   BookName  := "fr",
-  HTMLStart := "doc/chap0.html",
+  HTMLStart := "doc/chap0_mj.html",
   PDFFile   := "doc/manual.pdf",
   SixFile   := "doc/manual.six",
   LongTitle := "Functionally recursive and automata groups",

--- a/PackageInfo.g
+++ b/PackageInfo.g
@@ -8,10 +8,6 @@ Subtitle := "Computations with functionally recursive groups",
 Version := "2.4.9",
 Date := "31/07/2022", # dd/mm/yyyy format
 License := "GPL-2.0-or-later",
-## <#GAPDoc Label="Version">
-## <!ENTITY Version "2.4.9">
-## <!ENTITY Date "31/07/2022">
-## <#/GAPDoc>
 
 Persons := [
   rec(
@@ -79,5 +75,15 @@ AvailabilityTest := ReturnTrue,
 BannerString := Concatenation("Loading ", ~.PackageName, " ", String( ~.Version ), " ...\n"),
 
 TestFile := "tst/testall.g",
-Keywords := ["functionally recursive group", "mealy machine", "automata group"]
+Keywords := ["functionally recursive group", "mealy machine", "automata group"],
+
+AutoDoc := rec(
+    entities := rec(
+        Version := ~.Version,
+        Date := ~.Date,
+    ),
+    MainPage := false,
+    TitlePage := false,
+),
+
 ));

--- a/doc/fr.xml
+++ b/doc/fr.xml
@@ -4,7 +4,7 @@
 
 <!DOCTYPE Book SYSTEM "gapdoc.dtd" [
  <!ENTITY see '<Alt Only="LaTeX">$\to$</Alt><Alt Not="LaTeX">--&tgt;</Alt>'>
- <#Include Label="Version">
+ <#Include SYSTEM "_entities.xml">
 ]>
 <Book Name="FR">
 

--- a/makedoc.g
+++ b/makedoc.g
@@ -1,14 +1,11 @@
-#if fail = LoadPackage("AutoDoc", ">= 2016.01.21") then
-#    Error("AutoDoc 2016.01.21 or newer is required");
-#fi;
-#AutoDoc(rec(gapdoc := rec(files:=["PackageInfo.g"])));
-
-MakeGAPDocDoc("doc","fr",
-  ["../gap/frmachine.gd","../gap/frelement.gd","../gap/mealy.gd",
-   "../gap/group.gd","../gap/vector.gd","../gap/algebra.gd",
-   "../gap/examples.gd","../gap/helpers.gd","../gap/perlist.gd","../gap/cp.gd",
-   "../PackageInfo.g"],"fr","../../..");
-CopyHTMLStyleFiles("doc");
-GAPDocManualLab("fr");
+if fail = LoadPackage("AutoDoc", ">= 2019.04.10") then
+    Error("AutoDoc 2019.04.10 or newer is required");
+fi;
+AutoDoc(rec(
+    gapdoc := rec(
+        main:="fr.xml",
+        files:=["PackageInfo.g"],
+    )
+));
 
 QUIT;

--- a/makedoc.g
+++ b/makedoc.g
@@ -1,5 +1,5 @@
-if fail = LoadPackage("AutoDoc", ">= 2019.04.10") then
-    Error("AutoDoc 2019.04.10 or newer is required");
+if fail = LoadPackage("AutoDoc", ">= 2022.07.10") then
+    Error("AutoDoc 2022.07.10 or newer is required");
 fi;
 AutoDoc(rec(
     gapdoc := rec(


### PR DESCRIPTION
Avoid encoding the package version and release date multiple times.

This variant is a minimal change, but requires the very latest AutoDoc (which will be bundled with e.g. GAP 4.12). See PR #53 for an alternative that works with older AutoDoc versions but requires a somewhat bigger change.

Contains PR #52.
