### PR TITLE
changing to NC versions of PreImages...

### DIFF
--- a/gap/cp.gi
+++ b/gap/cp.gi
@@ -734,7 +734,7 @@ InstallMethod(FRBranchGroupConjugacyData,
 	 	Info(InfoFR, 1, "Init FRBranchGroupConjugacyData");
 		init := rec(initial_conj_dic:=NewDictionary([One(G),One(G)],true),
 								Branchstructure:=BranchStructure(G),
-								RepSystem:=List(~.Branchstructure.group,x->PreImagesRepresentative(~.Branchstructure.quo,x)));
+								RepSystem:=List(~.Branchstructure.group,x->PreImagesRepresentativeNC(~.Branchstructure.quo,x)));
 		N := TORSIONNUCLEUS@(G);
 		if N = fail then return fail;fi;
 		SEARCH@.INIT(G);
@@ -922,7 +922,7 @@ InstallMethod(IsConjugate,
 #SetFRBranchGroupConjugacyData(GrigorchukGroup,
 #	 rec(	initial_conj_dic:=NewDictionary([One(GrigorchukGroup),One(GrigorchukGroup)],true),
 #				Branchstructure:=BranchStructure(GrigorchukGroup),
-#				RepSystem:=List(~.Branchstructure.group,x->PreImagesRepresentative(~.Branchstructure.quo,x)))
+#				RepSystem:=List(~.Branchstructure.group,x->PreImagesRepresentativeNC(~.Branchstructure.quo,x)))
 #	 );
 #CallFuncList(function(a,b,c,d) 
 #							local G,D,g,h;
@@ -945,7 +945,7 @@ InstallMethod(IsConjugate,
 #SetFRBranchGroupConjugacyData(GuptaSidkiGroup,
 #	 rec(	initial_conj_dic:=NewDictionary([One(GuptaSidkiGroup),One(GuptaSidkiGroup)],true),
 #				Branchstructure:=BranchStructure(GuptaSidkiGroup),
-#				RepSystem:=List(~.Branchstructure.group,x->PreImagesRepresentative(~.Branchstructure.quo,x)))
+#				RepSystem:=List(~.Branchstructure.group,x->PreImagesRepresentativeNC(~.Branchstructure.quo,x)))
 #	 );
 #CallFuncList(function(a,t) 
 #							local G,D,g,h;
@@ -985,8 +985,8 @@ local f,gw,hw,Gen,a, b, c, d, Fam, aw, dw, ae, be, ce, de, Alph, x_1, x_2, K_rep
 	fi;	
 ############       (Local) GLOBALS           #####################
 	f := EpimorphismFromFreeGroup(G);
-	gw:=PreImagesRepresentative(f,g);
-	hw:=PreImagesRepresentative(f,h);
+	gw:=PreImagesRepresentativeNC(f,g);
+	hw:=PreImagesRepresentativeNC(f,h);
 	
 	Gen := GeneratorsOfGroup(G);
 	a:= Position(Gen,MealyElement([[4,2],[4,3],[5,1],[5,5],[5,5]],[(),(),(),(1,2),()],4));	
@@ -1284,7 +1284,7 @@ local f,gw,hw,Gen,a, b, c, d, Fam, aw, dw, ae, be, ce, de, Alph, x_1, x_2, K_rep
 			return [];
 		fi;
 		#L_gen := [[b],[a,b,a],[b,a,d,a,b,a,d,a],[a,b,a,d,a,b,a,d]];
-		g1_modL:=L_Decomp(PreImagesRepresentative(f,State(g,1))); 
+		g1_modL:=L_Decomp(PreImagesRepresentativeNC(f,State(g,1))); 
 		l:=g1_modL[2];
 		g1_modL:=LetterRepAssocWord(g1_modL[1]);
 		#See Lemma lem:conjugators_of_a for Details
@@ -1430,8 +1430,8 @@ local f,gw,hw,Gen,a, b, c, d, Fam, aw, dw, ae, be, ce, de, Alph, x_1, x_2, K_rep
 		else
 		#-#-#-#-#-#-#-#-#-   |g| > 1, act(g) = (1,2)    -#-#-#-#-#
 			#Test for Conjugator with trivial Activity
-			g1 := Compute_K_rep(PreImagesRepresentative(f,State(g,x_1)^-1));
-			h1 := Compute_K_rep(PreImagesRepresentative(f,State(h,x_1)));
+			g1 := Compute_K_rep(PreImagesRepresentativeNC(f,State(g,x_1)^-1));
+			h1 := Compute_K_rep(PreImagesRepresentativeNC(f,State(h,x_1)));
 			L1 := conjugators_grig_rek(State(g,x_1)*State(g,x_2),State(h,x_1)*State(h,x_2));
 			res_Con := [];
 			if Size(L1) > 0 then
@@ -1448,7 +1448,7 @@ local f,gw,hw,Gen,a, b, c, d, Fam, aw, dw, ae, be, ce, de, Alph, x_1, x_2, K_rep
 				od;
 			fi;
 			#Test for Conjugator with non-trivial Activity
-			h1 := Compute_K_rep(PreImagesRepresentative(f,State(h,x_2)));
+			h1 := Compute_K_rep(PreImagesRepresentativeNC(f,State(h,x_2)));
 			L1 := conjugators_grig_rek(State(g,x_1)*State(g,x_2),State(h,x_2)*State(h,x_1));
 			if Size(L1) = 0 then
 				return res_Con;

--- a/gap/frmachine.gi
+++ b/gap/frmachine.gi
@@ -1012,7 +1012,7 @@ InstallMethod(FRMachineRWS, "(FR) for an FR machine",
                    letterrep := w->LetterRepAssocWord(UnderlyingElement(w^iso)),
                    letterunrep := w->Product(mgens{w},One(M!.free)));
         gens := List(GeneratorsOfMonoid(Range(iso)),
-                     w->FRElement(M,PreImagesRepresentative(iso,w)));
+                     w->FRElement(M,PreImagesRepresentativeNC(iso,w)));
         inverse := List(gens,w->rws.letterrep(InitialState(w)^-1)[1]);
         rws.cyclicallyreduce := function(w)
             local i, j;
@@ -1637,14 +1637,14 @@ InstallMethod(SubFRMachine, "(FR) for a machine and a homomorphism",
     out := [];
     for i in GeneratorsOfGroup(Source(f)) do
         x := pi(i^f);
-        x[1] := List(x[1],g->PreImagesRepresentative(f,g));
+        x[1] := List(x[1],g->PreImagesRepresentativeNC(f,g));
         if fail in x[1] then return fail; fi;
         Add(trans,x[1]);
         Add(out,x[2]);
     od;
     x := FRMachineNC(FamilyObj(M),Source(f),trans,out);
     if HasAddingElement(M) then
-        i := PreImagesRepresentative(f,InitialState(AddingElement(M)));
+        i := PreImagesRepresentativeNC(f,InitialState(AddingElement(M)));
         if i<>fail then
             SetAddingElement(x,FRElement(x,i));
         fi;

--- a/gap/group.gd
+++ b/gap/group.gd
@@ -1775,7 +1775,7 @@ DeclareAttribute("BranchStructure", IsFRGroup, "mutable");
 ##     group would be obtained by setting <C>l=infinity</C>; for that purpose,
 ##     see <Ref Oper="IsomorphismSubgroupFpGroup"/>.
 ##
-##     <P/> Preimages can be computed, with <C>PreImagesRepresentative</C>.
+##     <P/> Preimages can be computed, with <C>PreImagesRepresentativeNC</C>.
 ##     They are usually reasonably short words, though by no means guaranteed
 ##     to be of minimal length.
 ##
@@ -1792,7 +1792,7 @@ DeclareAttribute("BranchStructure", IsFRGroup, "mutable");
 ##     c*a*b*a^-1*c^-1*a*b*a^-1*c*a*b, a*d*a*c*a*c*a*d*a*c*a*c*a*d*a*c*a*c*a*d*a*c*a*c,
 ##   a^-1*c*a*c*a^-1*c*a*b*a^-1*c*a*b*a^-1*c*a*c*a^-1*c*a*b*a^-1*c*a*b*a^-1*c*a*c*a^
 ##     -1*c*a*b*a^-1*c*a*b*a^-1*c*a*c*a^-1*c*a*b*a^-1*c*a*b ]
-## gap> PreImagesRepresentative(f,Comm(GrigorchukGroup.1,GrigorchukGroup.2));
+## gap> PreImagesRepresentativeNC(f,Comm(GrigorchukGroup.1,GrigorchukGroup.2));
 ## a*c*a*d*a*d*a*c
 ## gap> Source(f).4^f=GrigorchukGroup.4;
 ## true

--- a/gap/group.gi
+++ b/gap/group.gi
@@ -198,13 +198,13 @@ SEARCH@.CONJUGATE_COSET := function(G,c,x,y)
     K := BranchingSubgroup(G);
     K_pi := Image(G!.FRData.pi,K);
     if IsOne(x) and IsOne(y) then
-    	return PreImagesRepresentative(B.quo,c);
+    	return PreImagesRepresentativeNC(B.quo,c);
     fi;
     r := RepresentativeAction(Range(G!.FRData.pi),x^G!.FRData.pi,y^G!.FRData.pi);
     if r = fail then
     	return false;
     fi;
-    if not PreImagesRepresentative(B.quo,c)^G!.FRData.pi in Union(List(K_pi,z->RightCoset(Centralizer(Range(G!.FRData.pi),x^G!.FRData.pi),r*z))) then
+    if not PreImagesRepresentativeNC(B.quo,c)^G!.FRData.pi in Union(List(K_pi,z->RightCoset(Centralizer(Range(G!.FRData.pi),x^G!.FRData.pi),r*z))) then
         return false;
     else
         for s in G!.FRData.sphere do
@@ -1280,7 +1280,7 @@ InstallMethod(Enumerator, "(FR) for an FR semigroup",
                    G := G));
 end);
 
-InstallMethod(PreImagesRepresentative, "(FR) for a map to an FR group",
+InstallMethod(PreImagesRepresentativeNC, "(FR) for a map to an FR group",
         [IsGroupGeneralMappingByImages, IsMultiplicativeElementWithInverse],
         function(f,y)
     local iter, x;
@@ -2139,14 +2139,14 @@ InstallMethod(FRGroupByVirtualEndomorphism, "(FR) for a virtual endomorphism and
                 else
                     i := First([1..Length(T)],i->y*T[i] in Source(phi));
                 fi;
-                Add(t,PreImagesRepresentative(pi,(y/T[i])^phi));
+                Add(t,PreImagesRepresentativeNC(pi,(y/T[i])^phi));
                 Add(o,i);
             od;
             Add(trans,t);
             Add(out,o);
         od;
         M := FRMachineNC(FRMFamily([1..Index(G,Source(phi))]),F,trans,out);
-        F := Group(List(GeneratorsOfGroup(G),g->FRElement(M,PreImagesRepresentative(pi,g))));
+        F := Group(List(GeneratorsOfGroup(G),g->FRElement(M,PreImagesRepresentativeNC(pi,g))));
         SetCorrespondence(F,GroupHomomorphismByImagesNC(G,F,
                 GeneratorsOfGroup(G),GeneratorsOfGroup(F)));
         return F;

--- a/gap/helpers.gi
+++ b/gap/helpers.gi
@@ -209,7 +209,7 @@ InstallGlobalFunction(WordGrowth, function(arg)
                 trackgroup := FreeGroup(Length(GeneratorsOfGroup(g)));
             fi;
             trackgens := GroupHomomorphismByImages(trackgroup,g,GeneratorsOfGroup(trackgroup),GeneratorsOfGroup(g));
-            trackgens := List(gens,x->PreImagesRepresentative(trackgens,x));
+            trackgens := List(gens,x->PreImagesRepresentativeNC(trackgens,x));
             trackhom := GroupHomomorphismByImagesNC(trackgroup,g,GeneratorsOfGroup(trackgroup),GeneratorsOfGroup(g));
         elif IsMonoid(g) and not IsList(group) then
             if IsList(options.track) then
@@ -1075,7 +1075,7 @@ InstallGlobalFunction(CharneyBraidFpGroup, function(n)
     f := GroupHomomorphismByImages(B,SymmetricGroup(n),Bg,Sg);
     Sg := [];
     for i in SymmetricGroup(n) do if i<>() then
-        Add(Sg,PreImagesRepresentative(f,i));
+        Add(Sg,PreImagesRepresentativeNC(f,i));
     fi; od;
     return FpGroupPresentation(PresentationSubgroupMtc(B,Subgroup(B,Sg)));
 end);
@@ -1582,7 +1582,7 @@ BindGlobal("LIECOMPUTEBASIS@", function(A,d)
         Add(A!.basis[d],LIEELEMENT@(A,l));
     od;
     A!.transversal[d] := List(A!.pcp(Range(A!.hom[d])),
-                              x->PreImagesRepresentative(A!.hom[d],x));
+                              x->PreImagesRepresentativeNC(A!.hom[d],x));
 end);
 
 BindGlobal("JENNINGSSERIES@", function(G,p,d)
@@ -2159,7 +2159,7 @@ end);
 InstallMethod(ProjectiveQuotient, [IsProjectiveRepresentation,IsGroupHomomorphism],
         function(rep, epi)
     return ProjectiveRepresentationByFunction(Image(epi),Range(rep),
-                   x->CanonicalRightCosetElement(Kernel(epi),PreImagesRepresentative(epi,x))^rep);
+                   x->CanonicalRightCosetElement(Kernel(epi),PreImagesRepresentativeNC(epi,x))^rep);
 end);
         
 InstallMethod(CoboundaryMatrix, [IsGroup], function(G)

--- a/gap/linear.gi
+++ b/gap/linear.gi
@@ -1307,7 +1307,7 @@ end,
     od;
     info.hom := NaturalHomomorphismBySubspace(space,Subspace(space,kernel));
     info.basis := List(Basis(Range(info.hom)),
-                  v->PreImagesRepresentative(info.hom,v));
+                  v->PreImagesRepresentativeNC(info.hom,v));
     for i in info.where do
         i[3] := info.basis*i[3];
     od;
@@ -1346,7 +1346,7 @@ end,
         if v=[] then return Zero(V); else return fail; fi;
     fi;
     if v in Range(info.hom) then
-        return PreImagesRepresentative(info.hom,v)*info.gens;
+        return PreImagesRepresentativeNC(info.hom,v)*info.gens;
     else
         return fail;
     fi;

--- a/gap/mealy.gi
+++ b/gap/mealy.gi
@@ -2322,7 +2322,7 @@ BindGlobal("DEPTH_MEALYME@", function(M)
     d := List(StateSet(M),s->0);
     todo := [one];
     for i in todo do
-        for j in PreImages(fM,i) do if j <> one then
+        for j in PreImagesNC(fM,i) do if j <> one then
             if d[j]<=d[i] then
                 d[j] := d[i]+1;
                 Add(todo,j);

--- a/gap/vector.gi
+++ b/gap/vector.gi
@@ -169,7 +169,7 @@ BindGlobal("VECTORMINIMIZE@", function(fam,r,transitions,output,input,mode,docor
             ConvertToMatrixRep(f);
             f := NaturalHomomorphismBySubspace(W,Subspace(W,NullspaceMat(TransposedMat(f))));
             B := Basis(Range(f));
-            W := List(B,x->PreImagesRepresentative(f,x));
+            W := List(B,x->PreImagesRepresentativeNC(f,x));
             ConvertToMatrixRep(W);
             if input <> fail then
                 input := COEFF@(B,input^f);

--- a/init.g
+++ b/init.g
@@ -10,6 +10,15 @@
 ##
 #############################################################################
 
+#I introducing globally the NC versions of PreImages...  
+if not IsBound( PreImagesNC ) then 
+    BindGlobal( "PreImagesNC", PreImages ); 
+fi; 
+if not IsBound( PreImagesRepresentativeNC ) then 
+    BindGlobal( "PreImagesRepresentativeNC", PreImagesRepresentative ); 
+fi; 
+
+#############################################################################
 POSTHOOK@fr := []; # to be processed at the end
 
 BindGlobal("@", rec()); # a record to store locals in the package

--- a/tst/cp.tst
+++ b/tst/cp.tst
@@ -73,7 +73,7 @@ true
 gap> SetFRBranchGroupConjugacyData(GuptaSidkiGroup,
 >  rec(initial_conj_dic:=NewDictionary([One(GuptaSidkiGroup),One(GuptaSidkiGroup)],true),
 >     Branchstructure:=BranchStructure(GuptaSidkiGroup),
->     RepSystem:=List(~.Branchstructure.group,x->PreImagesRepresentative(~.Branchstructure.quo,x)))
+>     RepSystem:=List(~.Branchstructure.group,x->PreImagesRepresentativeNC(~.Branchstructure.quo,x)))
 >  );
 gap> CallFuncList(function(a,t) 
 >             local G,D,g,h;


### PR DESCRIPTION
PreImages, PreImagesElm, PreImagesSet and PreImagesRepresetnative, can all return incorrect results when the element(s) supplied are not in the range of the map.
This situation has been discussed in GAP issue #4809. 
To rectify the situation the plan is to have NC versions of these four operations and to add tests to the non-NC versions. 
The procedure to be adopted is as follows. 
(1) Rename the four operations by adding 'NC' to their names, and then declare the original operations as synonyms of these.  PR #5073 addresses this. 
(2) Ask package authors/maintainers to convert all their calls to these functions to the NC versions (unless there is good reason not to do so). 
A clause added to init.g ensures that the package still works in older versions of GAP.
(3) Once all the packages have been updated, add tests to the non-NC versions of the operations. 
This PR attempts to implement (2) for package fr which uses PreImages once and PreImagesRepresentative many times, including one InstallMethod. 
