### PR TITLE
Don't invoke ListPerm on transformations

### DIFF
--- a/gap/frelement.gi
+++ b/gap/frelement.gi
@@ -680,7 +680,7 @@ InstallMethod(ActivityInt, "(FR) for an FR machine and a state",
         function(E,l)
     local p, n, i, delta, x;
     n := Size(AlphabetOfFRObject(E));
-    p := ListPerm(Activity(E,l),n^l);
+    p := ANY2OUT@(Activity(E,l),n^l);
     if p=fail then return fail; fi;
     x := List([1..n^l],i->SEQ2INT@(Reversed(INT2SEQ@(i,l,n)),l,n));
     delta := Position(x,p[1])-1;

--- a/tst/chapter-5-a.tst
+++ b/tst/chapter-5-a.tst
@@ -1371,7 +1371,7 @@ gap> Info(InfoFR,1,"4.2.4 Activity");
 #I  4.2.4 Activity
 gap> 
 gap> for i in [1,2,3,4,5, 7,8 ] do
->   Print(ForAll(mealyel[i]{[1,2,  5]}, el_list -> List(el_list, g -> ListPerm(Activity(g, 1), Size(AlphabetOfFRObject(g)))) = outputsm[i]), "\n");
+>   Print(ForAll(mealyel[i]{[1,2,  5]}, el_list -> List(el_list, g -> ANY2OUT@FR(Activity(g, 1), Size(AlphabetOfFRObject(g)))) = outputsm[i]), "\n");
 > od;
 true
 true


### PR DESCRIPTION
This used to work "by accident", but in future GAP versions
ListPerm validates its inputs.
