### PR TITLE
Manual fixes

### DIFF
--- a/doc/fr.xml
+++ b/doc/fr.xml
@@ -464,7 +464,7 @@ into a rooted tree. The root represents the empty string, and the
 strings <M>x_1\ldots x_n</M> and <M>x_1\ldots x_{n+1}</M> are connected
 by an edge, for all <M>x_i\in X</M>.
 
-<Section Label="frmachine-types"><Heading>Types of machines</Heading>
+<Section Label="frmachineTypes"><Heading>Types of machines</Heading>
 Machines must be accessible to computation; therefore it is reasonable
 to assume that their alphabet <M>X</M> is finite.
 
@@ -493,7 +493,7 @@ either as a permutation or as a transformation. The command <C>Activity</C> itse
 will return a permutation if possible, and otherwise a transformation.
 </Section>
 
-<Section Label="frmachine-products"><Heading>Products of machines</Heading>
+<Section Label="frmachineProducts"><Heading>Products of machines</Heading>
 
 Machines can be combined in different manners. If two machines act on
 the same alphabet, then their <E>sum</E> and <E>product</E> are
@@ -630,7 +630,7 @@ elements. In practise, it is better to work with Mealy elements as
 often as possible.
 
 <P/> Products of Mealy machines behave in the same way as products of
-general FR machines, see <Ref Label="frmachine-products"/>. The only
+general FR machines, see <Ref Label="frmachineProducts"/>. The only
 difference is that now the sum and products of statesets are distinct;
 the sum of statesets being their disjoint union, and their product
 being their cartesian product.

--- a/doc/frbib.xml
+++ b/doc/frbib.xml
@@ -9,7 +9,7 @@
   <title>A free group of finite automata</title>
   <journal>Vestnik Moskov. Univ. Ser. I Mat. Mekh.</journal>
   <year>1983</year>
-  <volume>1983</volume>
+  <volume>4</volume>
   <number>4</number>
   <pages>12-14</pages>
   <issn>0201-7385</issn>
@@ -578,7 +578,7 @@
   <title>Commensurators of groups and reversible automata</title>
   <journal>Dopov. Nats. Akad. Nauk Ukr. Mat. Prirodozn. Tekh. Nauki</journal>
   <year>2000</year>
-  <volume>2000</volume>
+  <volume>12</volume>
   <number>12</number>
   <pages>36--39</pages>
   <issn>1025-6415</issn>

--- a/doc/frbib.xml
+++ b/doc/frbib.xml
@@ -9,6 +9,7 @@
   <title>A free group of finite automata</title>
   <journal>Vestnik Moskov. Univ. Ser. I Mat. Mekh.</journal>
   <year>1983</year>
+  <volume>1983</volume>
   <number>4</number>
   <pages>12-14</pages>
   <issn>0201-7385</issn>
@@ -577,6 +578,7 @@
   <title>Commensurators of groups and reversible automata</title>
   <journal>Dopov. Nats. Akad. Nauk Ukr. Mat. Prirodozn. Tekh. Nauki</journal>
   <year>2000</year>
+  <volume>2000</volume>
   <number>12</number>
   <pages>36--39</pages>
   <issn>1025-6415</issn>
@@ -763,8 +765,8 @@
   <title>Groups acting on trees: from local to global structure</title>
   <journal>Inst. Hautes Études Sci. Publ. Math.</journal>
   <year>2000</year>
-  <number>92</number>
-  <pages>113--150 (2001)</pages>
+  <volume>92</volume>
+  <pages>113--150</pages>
   <issn>0073-8301</issn>
   <mrnumber>MR1839488 (2002i:20041)</mrnumber>
   <mrclass>20E08</mrclass>
@@ -782,8 +784,8 @@
   <title>Lattices in product of trees</title>
   <journal>Inst. Hautes Études Sci. Publ. Math.</journal>
   <year>2000</year>
-  <number>92</number>
-  <pages>151--194 (2001)</pages>
+  <volume>92</volume>
+  <pages>151--194</pages>
   <issn>0073-8301</issn>
   <mrnumber>MR1839489 (2002i:20042)</mrnumber>
   <mrclass>20E08 (22E40)</mrclass>


### PR DESCRIPTION
I renamed two labels in the manual to avoid using a hyphen. The issue lies with GAPDoc, which does some substitutions that cause LaTeX errors (see https://github.com/frankluebeck/GAPDoc/issues/77), but I don't think there's any harm in renaming the labels here.

I also did some minor changes to the bibliography, since the `volume` field is mandatory in the BibTeX class `article`. I either changed the `number` field to `volume`, or added a new `volume` field (some Russian journals have a tendency to number their volumes by year, and often the volume field is then omitted in bibliographical data).