### PR TITLE
Remove namespace usage from 'fr'

### DIFF
--- a/TODO
+++ b/TODO
@@ -21,7 +21,7 @@ group:
   * Exponent, IsSolvable, IsNilpotent, IsSimple
   * smarter IsTorsion, IsTorsionFree, HasCongruenceProperty
   * SubexponentialGrowth
-  * SEARCH@.BALL should not compute full balls if #gens is large (>100)
+  * Fr.SEARCH.BALL should not compute full balls if #gens is large (>100)
   * complex of groups covering contracting group
 
 vhgroup:
@@ -48,7 +48,7 @@ linear, vector:
   * Minimize, nice vectors for algebra elements
   * extend / restrict scalars
   * "in" method
-  
+
 algebra:
   * test membership in an algebra
   * test nillity of algebra (akin to IsTorsion for groups)

--- a/doc/fr.xml
+++ b/doc/fr.xml
@@ -1406,7 +1406,7 @@ gap> Inverse(bacher(3));
     <Package>FR</Package>.
   </Description>
 </ManSection>
-<#Include Label="SEARCH@">
+<#Include Label="Fr.SEARCH">
 </Section>
 
 </Chapter>

--- a/gap/algebra.gi
+++ b/gap/algebra.gi
@@ -73,13 +73,13 @@ end);
 InstallMethod(SCAlgebra, "(FR) for a linear machine",
         [IsLinearFRMachine], SCAlgebraNC);
 
-BindGlobal("SCALGEBRAWITHONE@", function(M)
+Fr.SCALGEBRAWITHONE := ( function(M)
     local a;
     a := Objectify(NewType(CollectionsFamily(FREFamily(M)),
                  IsFRAlgebraWithOne and IsAttributeStoringRep),
                  rec());
     SetLeftActingDomain(a,LeftActingDomain(M));
-    SetCorrespondence(a,List(GeneratorsOfFRMachine(M),x->FRElement(M,x)));    
+    SetCorrespondence(a,List(GeneratorsOfFRMachine(M),x->FRElement(M,x)));
     SetUnderlyingFRMachine(a,M);
     if IsVectorFRMachineRep(M) then
         SetFilterObj(a,IsVectorFRElementSpace);
@@ -87,12 +87,12 @@ BindGlobal("SCALGEBRAWITHONE@", function(M)
     SetFilterObj(a,IsLinearFRElementSpace);
     return a;
 end);
-        
+
 InstallMethod(SCAlgebraWithOneNC, "(FR) for a linear machine",
         [IsLinearFRMachine],
         function(M)
     local a;
-    a := SCALGEBRAWITHONE@(M);
+    a := Fr.SCALGEBRAWITHONE(M);
     SetGeneratorsOfLeftOperatorRingWithOne(a,Correspondence(a));
     return a;
 end);
@@ -101,7 +101,7 @@ InstallMethod(SCAlgebraWithOne, "(FR) for a linear machine",
         [IsLinearFRMachine],
         function(M)
     local a, g, p;
-    a := SCALGEBRAWITHONE@(M);
+    a := Fr.SCALGEBRAWITHONE(M);
     g := DuplicateFreeList(Correspondence(a));
     if Length(g)>=1 then
         p := Position(g,One(g[1]));
@@ -115,11 +115,11 @@ InstallMethod(SCLieAlgebra, "(FR) for a linear machine",
         [IsLinearFRMachine],
         function(M)
     local a;
-    a := Objectify(NewType(CollectionsFamily(FRJFAMILY@(M)),
+    a := Objectify(NewType(CollectionsFamily(Fr.FRJFAMILY(M)),
                  IsFRAlgebra and IsAttributeStoringRep),
                  rec());
     SetLeftActingDomain(a,LeftActingDomain(M));
-    SetGeneratorsOfLeftOperatorRing(a,List(GeneratorsOfFRMachine(M),x->FRElement(M,x,IsJacobianElement)));    
+    SetGeneratorsOfLeftOperatorRing(a,List(GeneratorsOfFRMachine(M),x->FRElement(M,x,IsJacobianElement)));
     SetUnderlyingFRMachine(a,M);
     if IsVectorFRMachineRep(M) then
         SetFilterObj(a,IsVectorFRElementSpace);
@@ -134,7 +134,7 @@ end);
 #F FRAlgebra
 #F FRAlgebraWithOne
 ##
-BindGlobal("TOTALDEGREE@", function(x)
+Fr.TOTALDEGREE := ( function(x)
     local d, i;
     d := -1;
     x := ExtRepOfObj(x)[2];
@@ -144,7 +144,7 @@ BindGlobal("TOTALDEGREE@", function(x)
     return d;
 end);
 
-BindGlobal("STRINGSTOLMACHINE@", function(r,args,creator)
+Fr.STRINGSTOLMACHINE := ( function(r,args,creator)
     local temp, i, j, gens, transitions, output, data;
 
     if not IsRing(r) or not ForAll(args,IsString) then
@@ -165,11 +165,11 @@ BindGlobal("STRINGSTOLMACHINE@", function(r,args,creator)
     for temp in List(temp,x->x[2]) do
         temp := SplitString(temp,":");
         if Length(temp)=2 then
-            Add(output,STRING_ATOM2GAP@(temp[2])*One(r));
+            Add(output,Fr.STRING_ATOM2GAP(temp[2])*One(r));
         else
             Add(output,One(r));
         fi;
-        temp := STRING_WORD2GAP@(gens,GeneratorsOfAlgebraWithOne(data.holder),temp[1])*One(data.holder);
+        temp := Fr.STRING_WORD2GAP(gens,GeneratorsOfAlgebraWithOne(data.holder),temp[1])*One(data.holder);
         if not IsMatrix(temp) then
             Error("<arg> should have the form a=[[...]...]\n");
         fi;
@@ -178,7 +178,7 @@ BindGlobal("STRINGSTOLMACHINE@", function(r,args,creator)
 
     i := AlgebraMachine(r,data.holder,transitions,output);
     if ValueOption("IsVectorElement")=true or
-       (ForAll(Flat(transitions),x->TOTALDEGREE@(x)<=1) and ValueOption("IsAlgebraElement")<>true) then
+       (ForAll(Flat(transitions),x->Fr.TOTALDEGREE(x)<=1) and ValueOption("IsAlgebraElement")<>true) then
         i := AsVectorMachine(i);
         i := List(Correspondence(i),x->FRElement(i,x));
         for temp in [1..Length(gens)] do
@@ -194,24 +194,24 @@ end);
 
 InstallGlobalFunction(FRAlgebra,
         function(arg)
-    return STRINGSTOLMACHINE@(arg[1],arg{[2..Length(arg)]},Algebra);
+    return Fr.STRINGSTOLMACHINE(arg[1],arg{[2..Length(arg)]},Algebra);
 end);
 
 InstallGlobalFunction(FRAlgebraWithOne,
         function(arg)
-    return STRINGSTOLMACHINE@(arg[1],arg{[2..Length(arg)]},AlgebraWithOne);
+    return Fr.STRINGSTOLMACHINE(arg[1],arg{[2..Length(arg)]},AlgebraWithOne);
 end);
 
 InstallMethod(AssignGeneratorVariables, "(FR) for an FR algebra",
         [IsFRAlgebra],
         function(G)
-    ASSIGNGENERATORVARIABLES@(GeneratorsOfAlgebra(G));
+    Fr.ASSIGNGENERATORVARIABLES(GeneratorsOfAlgebra(G));
 end);
 
 InstallMethod(AssignGeneratorVariables, "(FR) for an FR algebra with one",
         [IsFRAlgebraWithOne],
         function(G)
-    ASSIGNGENERATORVARIABLES@(GeneratorsOfAlgebraWithOne(G));
+    Fr.ASSIGNGENERATORVARIABLES(GeneratorsOfAlgebraWithOne(G));
 end);
 ############################################################################
 
@@ -240,7 +240,7 @@ InstallMethod(ThinnedAlgebra, "(FR) for a ring and a FR semigroup",
     return a;
 end);
 
-BindGlobal("THINNEDALGEBRAWITHONE@",
+Fr.THINNEDALGEBRAWITHONE := (
         function(r,G,s)
     local a, g;
     g := List(s,x->AsLinearElement(r,x));
@@ -259,7 +259,7 @@ end);
 InstallMethod(ThinnedAlgebraWithOne, "(FR) for a ring and a FR monoid",
         [IsRing, IsFRMonoid],
         function(r,G)
-    return THINNEDALGEBRAWITHONE@(r,G,GeneratorsOfMonoid(G));
+    return Fr.THINNEDALGEBRAWITHONE(r,G,GeneratorsOfMonoid(G));
 end);
 
 InstallMethod(Embedding, "(FR) for a semigroup and a FR algebra",
@@ -277,7 +277,7 @@ end);
 ##
 #O Nillity
 ##
-BindGlobal("ISNIL_GENERIC@", function(x) # returns false or 2-powers of x till 0
+Fr.ISNIL_GENERIC := ( function(x) # returns false or 2-powers of x till 0
     local powx, rank, oldrank, ring;
 
     powx := [x];
@@ -309,7 +309,7 @@ BindGlobal("ISNIL_GENERIC@", function(x) # returns false or 2-powers of x till 0
     return powx;
 end);
 
-BindGlobal("ISNIL_FR@", function(x)
+Fr.ISNIL_FR := ( function(x)
     # return either a list of non-trivial 2-powers of x, or false
     local powx, deg, testing, found, recur;
 
@@ -319,7 +319,7 @@ BindGlobal("ISNIL_FR@", function(x)
     found := NewDictionary(x,true); # elements for which we found the nillity
     AddDictionary(testing,Zero(x),infinity);
     AddDictionary(found,Zero(x),1);
-    
+
     recur := function(x,mult,level,depth)
         local i, c, d, order;
 
@@ -334,13 +334,13 @@ BindGlobal("ISNIL_FR@", function(x)
         fi;
 
         AddDictionary(testing,x,mult);
-            
+
         # first see if element is triangular
         d := DecompositionOfFRElement(x);
-        
+
         # c are indices of diagonal blocks of size 1
         c := List(Filtered(List(EquivalenceClasses(StronglyConnectedComponents(TransitiveClosureBinaryRelation(BinaryRelationOnPoints(List([1..deg],i->Filtered([1..deg],j->not IsZero(d[i][j]))))))),AsList),x->Length(x)=1),c->c[1]);
-        
+
         order := 1;
         for i in c do
             i := recur(d[i][i],mult,level+1,1);
@@ -350,7 +350,7 @@ BindGlobal("ISNIL_FR@", function(x)
         if IsDiagonalMat(d) then
             return order;
         fi;
-        
+
         # now see if a projection is non-nil
 
         if IsVectorFRMachineRep(x) then
@@ -359,11 +359,11 @@ BindGlobal("ISNIL_FR@", function(x)
             d := LogInt(Length(Flat(ExtRepOfObj(InitialState(x)))),deg)+2;
         fi;
         if d > depth then # work at new depth
-            if ISNIL_GENERIC@(Activity(x,depth))=false then
+            if Fr.ISNIL_GENERIC(Activity(x,depth))=false then
                 return infinity;
             fi;
         fi;
-        
+
         i := recur(x*x,mult+1,level,d);
         AddDictionary(found,x,i);
         return i;
@@ -375,14 +375,14 @@ BindGlobal("ISNIL_FR@", function(x)
     return powx;
 end);
 
-BindGlobal("NILLITY@", function(x,isnil)
+Fr.NILLITY := ( function(x,isnil)
     local powx, pown, n, y;
 
     powx := isnil(x);
 
     if powx=false then return infinity; fi;
 
-    Append(powx,ISNIL_GENERIC@(Remove(powx))); # get all 2-powers of x
+    Append(powx,Fr.ISNIL_GENERIC(Remove(powx))); # get all 2-powers of x
     Remove(powx);
     pown := List([0..Length(powx)-1],i->2^i);
 
@@ -405,36 +405,36 @@ end);
 InstallOtherMethod(Nillity, "(FR) for an associative element",
 #        [IsAssociativeElement and IsMultiplicativeElementWithZero],
         [IsAssociativeElement and IsMultiplicativeElement],
-        x->NILLITY@(x,ISNIL_GENERIC@));
+        x->Fr.NILLITY(x,Fr.ISNIL_GENERIC));
 
 InstallMethod(Nillity, "(FR) for an FR element",
         [IsLinearFRElement],
-        x->NILLITY@(x,ISNIL_FR@));
+        x->Fr.NILLITY(x,Fr.ISNIL_FR));
 
 InstallOtherMethod(IsNilElement, "(FR) for an associative element",
 #        [IsAssociativeElement and IsMultiplicativeElementWithZero], ## removed "WithZero" filter, because GAP doesn't set it for linear elements
         [IsAssociativeElement and IsMultiplicativeElement],
-        x->ISNIL_GENERIC@(x)<>false);
+        x->Fr.ISNIL_GENERIC(x)<>false);
 
 InstallMethod(IsNilElement, "(FR) for an FR element",
         [IsLinearFRElement],
-        x->ISNIL_FR@(x)<>false);
+        x->Fr.ISNIL(x)<>false);
 
 InstallTrueMethod(IsHomogeneousElement,# "(FR) for a vector with degree",
         IsLinearFRElement and HasDegreeOfHomogeneousElement);
 
 InstallMethod(NucleusOfFRAlgebra, "(FR) for a ss algebra",
         [IsFRAlgebra],
-        A->LINEARNUCLEUS@(VectorSpace(LeftActingDomain(A),GeneratorsOfAlgebra(A))));
+        A->Fr.LINEARNUCLEUS(VectorSpace(LeftActingDomain(A),GeneratorsOfAlgebra(A))));
 
 InstallMethod(NucleusOfFRAlgebra, "(FR) for a ss algebra with one",
         [IsFRAlgebraWithOne],
-        A->LINEARNUCLEUS@(VectorSpace(LeftActingDomain(A),GeneratorsOfAlgebraWithOne(A))));
+        A->Fr.LINEARNUCLEUS(VectorSpace(LeftActingDomain(A),GeneratorsOfAlgebraWithOne(A))));
 
 InstallMethod(NucleusMachine, "(FR) for a ss algebra",
         [IsFRAlgebra],
         A->AsVectorMachine(NucleusOfFRAlgebra(A)));
-        
+
 InstallMethod(IsContracting, "(FR) for a ss algebra",
         [IsFRAlgebra],
         function(A)
@@ -486,7 +486,7 @@ end);
 ##
 #M View
 ##
-BindGlobal("VIEWALGEBRA@", function(A)
+Fr.VIEWALGEBRA := ( function(A)
     local n, x, y, s;
     if HasIsJacobianRing(A) and IsJacobianRing(A) then
         x := "Lie ";
@@ -511,11 +511,11 @@ end);
 
 InstallMethod(ViewString, "(FR) for an FR algebra",
         [IsFRAlgebra],
-        VIEWALGEBRA@);
+        Fr.VIEWALGEBRA);
 InstallMethod(ViewString, "(FR) for an FR algebra-with-one",
         [IsFRAlgebraWithOne],
-        VIEWALGEBRA@);
-INSTALLPRINTERS@(IsFRAlgebra);
-INSTALLPRINTERS@(IsFRAlgebraWithOne);
+        Fr.VIEWALGEBRA);
+Fr.INSTALLPRINTERS(IsFRAlgebra);
+Fr.INSTALLPRINTERS(IsFRAlgebraWithOne);
 ############################################################################
 

--- a/gap/bisets.gi
+++ b/gap/bisets.gi
@@ -16,7 +16,7 @@
 InstallMethod(BisetByFRMachine, [IsFRMachine],
         function(M)
     local b, g;
-    
+
     if IsMealyMachine(M) then
         if IsInvertible(M) then
             M := AsGroupFRMachine(M);
@@ -72,7 +72,7 @@ InstallMethod(ViewString, "(FR) for a biset",
     od;
     if not s[Length(s)] in " <" then Append(s," "); fi;
     if HasName(LeftActingDomain(b)) and HasName(RightActingDomain(b)) then
-        APPEND@(s,Name(LeftActingDomain(b)),"-",Name(RightActingDomain(b)),"-");
+        Fr.APPEND(s,Name(LeftActingDomain(b)),"-",Name(RightActingDomain(b)),"-");
     fi;
     Append(s,"biset>");
     return s;
@@ -82,7 +82,7 @@ InstallMethod(DisplayString, "(FR) for a biset",
         function(b)
     return Concatenation("Biset:\n",DisplayString(b!.machine));
 end);
-INSTALLPRINTERS@(IsFRBiset);
+Fr.INSTALLPRINTERS(IsFRBiset);
 
 ################################################################
 # biset elements
@@ -91,7 +91,7 @@ InstallMethod(BisetElement, "(FR) for a machine biset",
         [IsFRBiset,IsMultiplicativeElement,IsObject],
         function(biset,g,x)
     local type, elt;
-    
+
     type := NewType(FRBISET_FAMILY,IsBisetElement and IsBisetElementByPair);
     elt := rec(biset := biset, element := g, letter := x);
     return Objectify(type,elt);
@@ -101,7 +101,7 @@ InstallMethod(BisetElement, "(FR) for a homomorphism biset",
         [IsFRBisetByHomomorphismRep,IsMultiplicativeElement],
         function(biset,g)
     local type, elt;
-    
+
     type := NewType(FRBISET_FAMILY,IsBisetElement and IsBisetElementByElement);
     elt := rec(biset := biset, element := g);
     return Objectify(type,elt);
@@ -117,7 +117,7 @@ InstallMethod(\<, "(FR) for two biset elements",
         function(e,f)
     return e!.biset<f!.biset or (e!.biset=f!.biset and (e!.letter<f!.letter or (e!.letter=f!.letter and e!.element<f!.element)));
 end);
-         
+
 InstallMethod(\=, "(FR) for two biset elements",
         [IsBisetElementByElement,IsBisetElementByElement],
         function(e,f)
@@ -149,18 +149,18 @@ InstallOtherMethod(\*, "(FR) for a semigroup element and a biset element",
     if not g in RightActingDomain(b!.biset) then TryNextMethod(); fi;
     return BisetElement(b!.biset,g*b!.element,b!.letter);
 end);
-  
+
 InstallMethod(ViewString, "(FR) for a biset element by pair",
         [IsBisetElement and IsBisetElementByPair],
         function(e)
-    return CONCAT@("(",e!.element,"*",e!.letter,")");
+    return Fr.CONCAT("(",e!.element,"*",e!.letter,")");
 end);
 InstallMethod(PrintString, "(FR) for a biset element by pair",
         [IsBisetElement and IsBisetElementByPair],
         function(e)
-    return CONCAT@("BisetElement(",e!.biset,",",e!.element,",",e!.letter,")");
+    return Fr.CONCAT("BisetElement(",e!.biset,",",e!.element,",",e!.letter,")");
 end);
-INSTALLPRINTERS@(IsBisetElement);
+Fr.INSTALLPRINTERS(IsBisetElement);
 
 ################################################################
 # bases
@@ -173,18 +173,18 @@ InstallMethod(LeftBasis, "(FR) for a machine biset",
         [IsFRBiset and IsLeftFree],
         CanonicalBasis);
 
-BindGlobal("CANONICALBASIS@", function(b,alphabet)
+Fr.CANONICALBASIS := ( function(b,alphabet)
     return Objectify(NewType(FRBISET_FAMILY,IsLeftBisetBasis and IsCanonicalBasis),
                      List(alphabet,i->BisetElement(b,One(LeftActingDomain(b)),i)));
 end);
 
 InstallMethod(CanonicalBasis, "(FR) for a machine biset",
         [IsFRBisetByFRMachineRep],
-        b->CANONICALBASIS@(b,AlphabetOfFRObject(b!.machine)));
+        b->Fr.CANONICALBASIS(b,AlphabetOfFRObject(b!.machine)));
 
 InstallMethod(CanonicalBasis, "(FR) for a machine biset",
         [IsFRBisetByFRSemigroupRep],
-        b->CANONICALBASIS@(b,AlphabetOfFRSemigroup(b!.semigroup)));
+        b->Fr.CANONICALBASIS(b,AlphabetOfFRSemigroup(b!.semigroup)));
 
 InstallMethod(ELM_LIST, "(FR) for a biset basis",
         [IsBisetBasis,IsPosInt],
@@ -243,5 +243,5 @@ InstallMethod(ViewString, "(FR) for a biset basis",
         function(basis)
     return "RightBasis(...)";
 end);
-INSTALLPRINTERS@(IsBisetBasis);
+Fr.INSTALLPRINTERS(IsBisetBasis);
 

--- a/gap/cp.gi
+++ b/gap/cp.gi
@@ -17,9 +17,9 @@
 #-- Example: L=[[A,B,X],[C,D],[c,d]], dep=[[1],[2,3]] results --
 #--   in [[A,C,c],[A,D,d],[B,C,c],[B,D,d],[X,C,c],[X,D,d]	   ---
 #--     The Lists, which are joined by the dependencies      ---
-#--            have to be of the same length	               ---	
+#--            have to be of the same length	               ---
 #---------------------------------------------------------------
-BindGlobal("DEP_CARTESIAN@", function(L,dep)
+Fr.DEP_CARTESIAN := ( function(L,dep)
 	local res_list, temp_cart, container, al, d, i ,j,a;
 	res_list := [];
 	temp_cart := [];
@@ -33,9 +33,9 @@ BindGlobal("DEP_CARTESIAN@", function(L,dep)
 				fi;
 			od;
 			if al <> [] then container[j]:=al; fi;
-		od; 
+		od;
 		Add(temp_cart,container);
-	od; 
+	od;
 	temp_cart := Cartesian(temp_cart);
 	for i in temp_cart do
 		container := [];
@@ -52,11 +52,11 @@ end);
 #------  Takes two FRElements and computes a list of    -------
 #------  conjugators of the action on the first level.  -------
 #--------------------------------------------------------------
-BindGlobal("LEVEL_PERM_CONJ@", function(arg)
+Fr.LEVEL_PERM_CONJ := ( function(arg)
 	local G, pi_x, pi_y, c;
 	if Length(arg) < 3 then
 		G:=SymmetricGroup(AlphabetOfFRObject(arg[1]));
-	else 
+	else
 		if not IsFRObject(arg[1]) or not IsFRObject(arg[2]) or not IsPermGroup(arg[3]) then
 			Error("Usage: FRelm, FRelm, [PermGroup]");
 		fi;
@@ -98,8 +98,8 @@ function(a)
 					Add(OS_new,new);
 				fi;
 			od;
-			
-		od; 
+
+		od;
 		Append(OS_list,OS_unvisited);
 		OS_unvisited := OS_new;
 	od;
@@ -114,21 +114,21 @@ end
 #`````````````````````                  `````````````````````````#
 #````````````````````````````````````````````````````````````````#
 ##################################################################
-BindGlobal("CONJUGATOR_GRAPH@", function(a,b)
+Fr.CONJUGATOR_GRAPH := ( function(a,b)
 	local Alph, Vertices, Edges, c, d, p, v_id, e_id, v, orbits, orb_repr, i, new_con_pair, new_v, w, change, found, e, all_found;
-	
+
 	Alph := AlphabetOfFRObject(a);
 	Vertices := [];
 	Edges := [];
 	#--------------------- Save some work, in easy cases--------
-	if Size(LEVEL_PERM_CONJ@(a,b))=0 then
+	if Size(Fr.LEVEL_PERM_CONJ(a,b))=0 then
 		return [[],[]];
 	fi;
 	#--------------------- Generate the Vertex list ------------
 	v_id := 1;
 	for c in OrbitSignalizer(a) do
 		for d in OrbitSignalizer(b) do
-			for p in LEVEL_PERM_CONJ@(c,d) do
+			for p in Fr.LEVEL_PERM_CONJ(c,d) do
 				Add(Vertices,rec(	id:= v_id,
 													conj_pair := [c,d],
 													action := p));
@@ -137,7 +137,7 @@ BindGlobal("CONJUGATOR_GRAPH@", function(a,b)
 		od;
 	od;
 	#Print("Vertexlist generated\n");
-	
+
 	#--------------------- Find the Edges  -------------------
 	e_id := 1;
 	for v in Vertices do
@@ -147,7 +147,7 @@ BindGlobal("CONJUGATOR_GRAPH@", function(a,b)
 		orb_repr := List(orbits,Minimum);
 		for i in [1..Length(orbits)] do
 			new_con_pair := [State(c^Length(orbits[i]),orb_repr[i]),State(d^Length(orbits[i]),orb_repr[i]^v.action)];
-			for p in LEVEL_PERM_CONJ@(new_con_pair[1],new_con_pair[2]) do
+			for p in Fr.LEVEL_PERM_CONJ(new_con_pair[1],new_con_pair[2]) do
 				new_v := 0;
 				for w in Vertices do
 					if w.conj_pair = new_con_pair and w.action = p then;
@@ -162,7 +162,7 @@ BindGlobal("CONJUGATOR_GRAPH@", function(a,b)
 													read := orb_repr[i],
 													write := orb_repr[i]^v.action,
 													id := e_id));
-					e_id := e_id +1;	
+					e_id := e_id +1;
 				else #This case should never happen...
 					Error("Error the element is not in the vertex set!\n");
 				fi;
@@ -170,7 +170,7 @@ BindGlobal("CONJUGATOR_GRAPH@", function(a,b)
 		od;
 	od;
 	#Print(Size(Edges)," Edges generated\n");
-	
+
 	#--------------------- Delete dead Vertices  -------------------
 	change:=true;
 	while change do
@@ -209,7 +209,7 @@ BindGlobal("CONJUGATOR_GRAPH@", function(a,b)
 	return [Vertices,Edges];
 end);
 
-BindGlobal("DRAW_GRAPH@",function(Vertices,Edges)
+Fr.DRAW_GRAPH := (function(Vertices,Edges)
 	local v,S,e;
 	for v in Vertices do
 		Print("ID: ",v.id," Name: (",v.conj_pair[1]![2],",",v.conj_pair[2]![2],")\n");
@@ -245,11 +245,11 @@ BindGlobal("DRAW_GRAPH@",function(Vertices,Edges)
 	od;
 	Append(S,"}");
 	Print(S);
-	DOT2DISPLAY@(S,"dot");
+	Fr.DOT2DISPLAY(S,"dot");
 end);
 ##################################################################
 #````````````````````````````````````````````````````````````````#
-#```````````````````  MEALY_FROM_STATES@  ```````````````````````#
+#```````````````````  Fr.MEALY_FROM_STATES  ```````````````````````#
 #````````````````                            ````````````````````#
 #`````````````````  Computes a mealy machine ````````````````````#
 #````````````````     with Statesset L and   ````````````````````#
@@ -257,7 +257,7 @@ end);
 #````````````````````````````````````````````````````````````````#
 ##################################################################
 #Computes a mealy machine with stateset L and given activity act.
-BindGlobal("MEALY_FROM_STATES@", function(L,act)
+Fr.MEALY_FROM_STATES := ( function(L,act)
 		local m,tran,out,i,j;
 		#Force L to contain elements and not lists of elements.
 		for i in [1..Size(L)] do
@@ -269,7 +269,7 @@ BindGlobal("MEALY_FROM_STATES@", function(L,act)
 		if IsPerm(act) then
 			act := List(AlphabetOfFRObject(L[1]),x->x^act);
 		fi;
-		
+
 		tran := [[]];
 		out := [act];
 		i := 1;
@@ -290,13 +290,13 @@ BindGlobal("MEALY_FROM_STATES@", function(L,act)
 #`````````````````````                  `````````````````````````#
 #````````````````````````````````````````````````````````````````#
 ##################################################################
-BindGlobal("CONJUGATORS_FINITE_STATE_WRAPPER@",function(start,CG)
+Fr.CONJUGATORS_FINITE_STATE_WRAPPER := (function(start,CG)
 	local v,AS,to_visit, Alph, new_v, i, found, e, Tran, Act, c,d, orbit;
 			#--------- Choose one subgraph, as automaton  ---------
 			AS := [start.id]; #Contains IDs of vertices, which build the subgraph
-			to_visit := [start.id]; 
+			to_visit := [start.id];
 			Alph := AlphabetOfFRObject(start.conj_pair[1]);
-			while Length(to_visit) > 0 do 
+			while Length(to_visit) > 0 do
 				new_v := [];
 				for i in to_visit do
 					v := CG[1][i];
@@ -305,7 +305,7 @@ BindGlobal("CONJUGATORS_FINITE_STATE_WRAPPER@",function(start,CG)
 						if e.from = v.id then
 							if e.read in found then
 								Unbind(CG[2][e.id]);
-							else 
+							else
 								Add(found,e.read);
 								if not e.to in AS then
 									Add(new_v,CG[1][e.to].id);
@@ -345,12 +345,12 @@ end);
 #`````````````````````                  `````````````````````````#
 #````````````````````````````````````````````````````````````````#
 ##################################################################
-BindGlobal("CONJUGATORS_FINITARY_WRAPPER@",function(v,Graph,Seen,Known_vertex_conjugator)
+Fr.CONJUGATORS_FINITARY_WRAPPER := (function(v,Graph,Seen,Known_vertex_conjugator)
 	local CONJUGATORS_FINITARY_REK;
 	CONJUGATORS_FINITARY_REK := function(v,Graph,Seen,Known_vertex_conjugator)
 		local Vertices,Edges,sons,starts,conj_cand,conjugators_found,son,x,NewSeen,a,b,e,son_conj,son_conjs,tempo_conj, htemp,tempoconj,err,Indices,diction,pos,real_conj,real_conjugators,i,j,ip,son_orbit_size,Alph,action,
 		w,Circle,Conjs,con;
-	
+
 		#Print("@Vertex ",v,"\n");
 		if IsBound(Known_vertex_conjugator[v]) then #Don't do the same work twice.
 			return Known_vertex_conjugator[v];
@@ -361,7 +361,7 @@ BindGlobal("CONJUGATORS_FINITARY_WRAPPER@",function(v,Graph,Seen,Known_vertex_co
 		b := Vertices[v].conj_pair[2];
 		Alph := AlphabetOfFRObject(a);
 		action := Vertices[v].action;
-	
+
 		if v in Seen then
 			Circle:=Seen{[Position(Seen,v)..Size(Seen)]}; #are all one then.
 			for w in Circle do
@@ -374,7 +374,7 @@ BindGlobal("CONJUGATORS_FINITARY_WRAPPER@",function(v,Graph,Seen,Known_vertex_co
 			od;
 			return [One(a)];
 		fi;
-	
+
 		sons := [];
 		for e in Edges do
 			if e.from = v then
@@ -387,7 +387,7 @@ BindGlobal("CONJUGATORS_FINITARY_WRAPPER@",function(v,Graph,Seen,Known_vertex_co
 			conj_cand[x] := [];
 		od;
 		conjugators_found := [];
-	
+
 		for son in sons do
 			NewSeen := ShallowCopy(Seen);
 			Add(NewSeen,v);
@@ -418,8 +418,8 @@ BindGlobal("CONJUGATORS_FINITARY_WRAPPER@",function(v,Graph,Seen,Known_vertex_co
 		od;
 		#Test if we have enough partial conjugators
 		if IsDenseList(conjugators_found) and Size(conjugators_found) = Size(Alph) then
-			#puzzle them together!	
-			Conjs := DEP_CARTESIAN@(conj_cand,Orbits(Group(a),Alph));
+			#puzzle them together!
+			Conjs := Fr.DEP_CARTESIAN(conj_cand,Orbits(Group(a),Alph));
 			for con in Conjs do
 				Add(real_conjugators,FRElement([con],[action],[1]));
 			od;
@@ -436,11 +436,11 @@ end);
 #`````````````````````                  `````````````````````````#
 #````````````````````````````````````````````````````````````````#
 ##################################################################
-BindGlobal("CONJUGATORS_BOUNDED_WRAPPER@",function(v,Graph,Seen,readwrite_path,Known_vertex_conjugator)
+Fr.CONJUGATORS_BOUNDED_WRAPPER := (function(v,Graph,Seen,readwrite_path,Known_vertex_conjugator)
 	local CONJUGATORS_BOUNDED_REK;
 	CONJUGATORS_BOUNDED_REK := function(v,Graph,Seen,readwrite_path,Known_vertex_conjugator)
 		local Vertices,Edges,sons,starts,conj_cand,conjugators_found,son,x,NewSeen,a,b,e,son_conj,son_conjs,tempo_conj, htemp,tempoconj,err,Indices,diction,pos,real_conj,real_conjugators,conj_cand_aux,i,j,ip,son_orbit_size,Alph,Alph_num,action, alph,beta,Conj_elm,read,write,orb_size,Conj_Tran,Conj_act,m,read_path,write_path,action_path,New_read_path, New_write_path,New_action_path,Conj_Tran_el,Conjs,circle_length,New_Seen,X,con, check_need ;
-	
+
 		#Print("@Vertex ",v,"\n");
 		if IsBound(Known_vertex_conjugator[v]) then #Don't do the same work twice.
 			return Known_vertex_conjugator[v];
@@ -482,8 +482,8 @@ BindGlobal("CONJUGATORS_BOUNDED_WRAPPER@",function(v,Graph,Seen,readwrite_path,K
 					x:= read;
 					#Get a representative for the orbits
 					X:=Difference(Alph,Orbit(Group(alph),x));
-					while Size(X)>0 do 
-						x := Minimum(X);				
+					while Size(X)>0 do
+						x := Minimum(X);
 						sons := [];
 						for e in Edges do
 							if e.from = v and e.read = x then
@@ -494,12 +494,12 @@ BindGlobal("CONJUGATORS_BOUNDED_WRAPPER@",function(v,Graph,Seen,readwrite_path,K
 						son_conjs:= [];
 						#Here there is already one circle, so the other states have to be finitary
 						for son in sons do
-								Conjs :=CONJUGATORS_FINITARY_WRAPPER@(son,Graph,New_Seen,Known_vertex_conjugator);
+								Conjs :=Fr.CONJUGATORS_FINITARY_WRAPPER(son,Graph,New_Seen,Known_vertex_conjugator);
 								Append(son_conjs,Conjs);
-						od;		
+						od;
 						for son_conj in son_conjs do
-							for j in [0..Size(Orbit(Group(alph),x))-1] do 
-								Add(Conj_elm[Position(Alph,x^(alph^j))],[(State(alph^j,x))^-1*son_conj*State(beta^j,x^action_path[i])]); 
+							for j in [0..Size(Orbit(Group(alph),x))-1] do
+								Add(Conj_elm[Position(Alph,x^(alph^j))],[(State(alph^j,x))^-1*son_conj*State(beta^j,x^action_path[i])]);
 							od;
 						od;
 						X:=Difference(X,Orbit(Group(alph),x)); #next orbit
@@ -515,7 +515,7 @@ BindGlobal("CONJUGATORS_BOUNDED_WRAPPER@",function(v,Graph,Seen,readwrite_path,K
 				for x in Alph_num do
 					Conj_elm[x] := Set(Conj_elm[x]);
 				od;
-				Conj_elm := DEP_CARTESIAN@(Conj_elm,Orbits(Group(alph),Alph)); #puzzle the conjugators together
+				Conj_elm := Fr.DEP_CARTESIAN(Conj_elm,Orbits(Group(alph),Alph)); #puzzle the conjugators together
 				Add(Conj_act,action_path[i]);
 				Add(Conj_Tran,Conj_elm);
 			od;
@@ -551,7 +551,7 @@ BindGlobal("CONJUGATORS_BOUNDED_WRAPPER@",function(v,Graph,Seen,readwrite_path,K
 			conj_cand[x] := [];
 		od;
 		conjugators_found := [];
-	
+
 		for son in sons do
 			NewSeen := ShallowCopy(Seen);
 			Add(NewSeen,v);
@@ -561,7 +561,7 @@ BindGlobal("CONJUGATORS_BOUNDED_WRAPPER@",function(v,Graph,Seen,readwrite_path,K
 			Add(New_write_path,son[2]^action);
 			New_action_path := ShallowCopy(action_path);
 			Add(New_action_path,action);
-				
+
 			son_conjs := CONJUGATORS_BOUNDED_REK(son[1],Graph,NewSeen,[New_read_path,New_write_path,New_action_path],Known_vertex_conjugator);
 			for son_conj in son_conjs do
 			son_orbit_size := Size(Orbit(Group(a),son[2]));
@@ -573,8 +573,8 @@ BindGlobal("CONJUGATORS_BOUNDED_WRAPPER@",function(v,Graph,Seen,readwrite_path,K
 		od;
 		#Test if we have enough partial conjugators
 		if IsDenseList(conjugators_found) and Size(conjugators_found) = Size(Alph) then
-			#puzzle them together!	
-			Conjs := DEP_CARTESIAN@(conj_cand,Orbits(Group(a),Alph));
+			#puzzle them together!
+			Conjs := Fr.DEP_CARTESIAN(conj_cand,Orbits(Group(a),Alph));
 			for con in Conjs do
 				Add(real_conjugators,FRElement([con],[action],[1]));
 			od;
@@ -593,16 +593,16 @@ end);
 InstallMethod(IsConjugate,
 	"For Aut, RAut, FAut, Poly-1, Poly0",
 	#The attribute FullSCVertex charakterizes all FullSCGroups
-	[ IsFRGroup and HasFullSCVertex,IsFRElement,IsFRElement], 
+	[ IsFRGroup and HasFullSCVertex,IsFRElement,IsFRElement],
   function(G,a,b)
   	local v, Graph, sons, starts;
   	if AlphabetOfFRSemigroup(G) <> AlphabetOfFRObject(a) or AlphabetOfFRSemigroup(G) <> AlphabetOfFRObject(b) then
   		return false;
   	fi;
   	if a = b then #Spare Computing Time in trivial case.
-  	 return true; 
-  	fi; 
-  	Graph := CONJUGATOR_GRAPH@(a,b);
+  	 return true;
+  	fi;
+  	Graph := Fr.CONJUGATOR_GRAPH(a,b);
   	if FullSCFilter(G) = IsFRElement or FullSCFilter(G) = IsFiniteStateFRElement then
 		#In this cases the conjugacy problems are equivalent,
 		#----------------------FiniteState-----------------;
@@ -622,13 +622,13 @@ InstallMethod(IsConjugate,
 				fi;
 			od;
 			for v in starts do;
-				if Size(CONJUGATORS_FINITARY_WRAPPER@(v,Graph,[],[]))>0 then
+				if Size(Fr.CONJUGATORS_FINITARY_WRAPPER(v,Graph,[],[]))>0 then
 					return true;
 				fi;
 			od;
-			return false;	
+			return false;
 		elif FullSCFilter(G) = IsBoundedFRElement then
-		#----------------------Bounded---------------------;		
+		#----------------------Bounded---------------------;
 			starts := [];
 			for v in Graph[1] do
 				if v.conj_pair = [a,b] then
@@ -636,13 +636,13 @@ InstallMethod(IsConjugate,
 				fi;
 			od;
 			for v in starts do
-				if Size(CONJUGATORS_BOUNDED_WRAPPER@(v,Graph,[],[[],[],[]],[]))>0 then
+				if Size(Fr.CONJUGATORS_BOUNDED_WRAPPER(v,Graph,[],[[],[],[]],[]))>0 then
 					return true;
 				fi;
 			od;
 			return false;
 		else
-		#----------------------Else------------------------;	
+		#----------------------Else------------------------;
 			TryNextMethod();
 		fi;
   end
@@ -651,16 +651,16 @@ InstallMethod(IsConjugate,
 InstallOtherMethod(RepresentativeActionOp,
 	"Computes a conjugator in the given FullSCGroup ",
 	#The attribute FullSCVertex charakterizes all FullSCGroups
-	[ IsFRGroup and HasFullSCVertex,IsFRElement,IsFRElement], 
+	[ IsFRGroup and HasFullSCVertex,IsFRElement,IsFRElement],
 	function(G,a,b)
   	local CG, v, start, Conjugators;
   	if AlphabetOfFRSemigroup(G) <> AlphabetOfFRObject(a) or AlphabetOfFRSemigroup(G) <> AlphabetOfFRObject(b) then
   		return fail;
   	fi;
   	if a=b then
-  	 return One(G); 
+  	 return One(G);
   	fi;
-  	CG := CONJUGATOR_GRAPH@(a,b);
+  	CG := Fr.CONJUGATOR_GRAPH(a,b);
   	if FullSCFilter(G) = IsFRElement or FullSCFilter(G) = IsFiniteStateFRElement then
 		#In this cases the conjugacy problems are equivalent,
 		#----------------------FiniteState-----------------;
@@ -674,7 +674,7 @@ InstallOtherMethod(RepresentativeActionOp,
 			if not IsBound(start) then
 				return fail;
 			fi;
-			return CONJUGATORS_FINITE_STATE_WRAPPER@(start,CG);
+			return Fr.CONJUGATORS_FINITE_STATE_WRAPPER(start,CG);
 		elif FullSCFilter(G) = IsFinitaryFRElement then
 		#----------------------Finitary--------------------;
 			start := [];
@@ -684,14 +684,14 @@ InstallOtherMethod(RepresentativeActionOp,
 				fi;
 			od;
 			for v in start do
-				Conjugators :=CONJUGATORS_FINITARY_WRAPPER@(v,CG,[],[]);
+				Conjugators :=Fr.CONJUGATORS_FINITARY_WRAPPER(v,CG,[],[]);
 				if Size(Conjugators)>0 then
 					return Conjugators[1];
 				fi;
 			od;
-			return fail;		
+			return fail;
 		elif FullSCFilter(G) = IsBoundedFRElement then
-		#----------------------Bounded---------------------;		
+		#----------------------Bounded---------------------;
 			start := [];
 			for v in CG[1] do
 				if v.conj_pair = [a,b] then
@@ -699,14 +699,14 @@ InstallOtherMethod(RepresentativeActionOp,
 				fi;
 			od;
 			for v in start do
-				Conjugators :=CONJUGATORS_BOUNDED_WRAPPER@(v,CG,[],[[],[],[]],[]);
+				Conjugators :=Fr.CONJUGATORS_BOUNDED_WRAPPER(v,CG,[],[[],[],[]],[]);
 				if Size(Conjugators)>0 then
 					return Conjugators[1];
 				fi;
 			od;
 			return fail;
 		else
-		#----------------------Else------------------------;	
+		#----------------------Else------------------------;
 			TryNextMethod();
 		fi;
   end);
@@ -717,34 +717,34 @@ InstallOtherMethod(RepresentativeActionOp,
 ###############  Algorithm for branch groups  ##################*
 ###############                               ##################*
 ################################################################*
-################################################################* 
+################################################################*
 #****************************************************************
 
 
 #---------------------------------------------------------------
 #------      InitConjugateForBranchGroups      -----------------
 #--   Sets the Precomputed initial data for the branch			 ---
-#--  Algorithm. Stores this data for later computations.     ---  	
+#--  Algorithm. Stores this data for later computations.     ---
 #---------------------------------------------------------------
 
 InstallMethod(FRBranchGroupConjugacyData,
-	[ IsFRGroup ],	
+	[ IsFRGroup ],
 	 function(G)
 	 	local init, N, g, h, b, CT, c, i;
 	 	Info(InfoFR, 1, "Init FRBranchGroupConjugacyData");
 		init := rec(initial_conj_dic:=NewDictionary([One(G),One(G)],true),
 								Branchstructure:=BranchStructure(G),
 								RepSystem:=List(~.Branchstructure.group,x->PreImagesRepresentativeNC(~.Branchstructure.quo,x)));
-		N := TORSIONNUCLEUS@(G);
+		N := Fr.TORSIONNUCLEUS(G);
 		if N = fail then return fail;fi;
-		SEARCH@.INIT(G);
+		Fr.SEARCH.INIT(G);
 		for g in N do
 			for h in N do
 				#Find one conjugator b
-				repeat 
-				 	b := SEARCH@.CONJUGATE(G,g,h);
-				 	while b=fail and SEARCH@.EXTEND(G)=fail do
-            SEARCH@.ERROR(G,"RepresentativeAction");
+				repeat
+				 	b := Fr.SEARCH.CONJUGATE(G,g,h);
+				 	while b=fail and Fr.SEARCH.EXTEND(G)=fail do
+            Fr.SEARCH.ERROR(G,"RepresentativeAction");
         	od;
         	Info(InfoFR, 3, "RepresentativeAction: searching at level ",G!.FRData.level," and in sphere of radius ",G!.FRData.radius);
         until b<>fail;
@@ -753,9 +753,9 @@ InstallMethod(FRBranchGroupConjugacyData,
 		    	i := 1;
 		    	for c in init.Branchstructure.group do
 		    		repeat
-        			b := SEARCH@.CONJUGATE_COSET(G,c,g,h);
-				    	while b=fail and SEARCH@.EXTEND(G)=fail do
-				        SEARCH@.ERROR(G,"RepresentativeAction");
+        			b := Fr.SEARCH.CONJUGATE_COSET(G,c,g,h);
+				    	while b=fail and Fr.SEARCH.EXTEND(G)=fail do
+				        Fr.SEARCH.ERROR(G,"RepresentativeAction");
 				    	od;
 				    until b<>fail;
 				    if b <> false then
@@ -776,8 +776,8 @@ InstallMethod(FRBranchGroupConjugacyData,
 #`````````````````````   Branch Worker  `````````````````````````#
 #`````````````````````                  `````````````````````````#
 #````````````````````````````````````````````````````````````````#
-##################################################################	
-BindGlobal("CONJUGATORS_BRANCH@",function(G,g,h)
+##################################################################
+Fr.CONJUGATORS_BRANCH := (function(G,g,h)
 	local CP_init, Start, B, BS, Con_dic, saved_quo, quo, Alph, Conjugators_branch_rek,l,k,rek_count;
 	CP_init := FRBranchGroupConjugacyData(G);
 	if CP_init = fail then
@@ -810,7 +810,7 @@ BindGlobal("CONJUGATORS_BRANCH@",function(G,g,h)
 		fi;
 		if not HasName(h) then
 			SetName(h,Concatenation("h_",String(rek_count)));
-		fi; 
+		fi;
 		rek_count := rek_count +1;
 		Info(InfoFR,3,"Computing g,h=",Name(g),",",Name(h),"");
 		if IsOne(g) or IsOne(h) then
@@ -830,7 +830,7 @@ BindGlobal("CONJUGATORS_BRANCH@",function(G,g,h)
 		orb_repr := List(orbits,Minimum);
 		CT := []; # Resulting Conjugator Tuple
 		Info(InfoFR,3,"Computing g,h=",Name(g),",",Name(h),"     Orbit: ",orbits);
-		for p in LEVEL_PERM_CONJ@(g,h,BS.top) do
+		for p in Fr.LEVEL_PERM_CONJ(g,h,BS.top) do
 			Info(InfoFR,3,"Computing g,h=",Name(g),",",Name(h),"     Try a conjugator with activity ",p);
 			L := [];
 			L_Pos := []; #Stores the position at which the conjugator tuples are defined.
@@ -850,27 +850,27 @@ BindGlobal("CONJUGATORS_BRANCH@",function(G,g,h)
 							L_PosC[k] := k;
 						fi;
 					od;
-					L[orb_repr[i]^(g^j)]:=LC ; 
-					L_Pos[orb_repr[i]^(g^j)]:=L_PosC;	
+					L[orb_repr[i]^(g^j)]:=LC ;
+					L_Pos[orb_repr[i]^(g^j)]:=L_PosC;
 				od;
 				Add(dep,orbits[i]);
-			od; 
+			od;
 			if Size(L)>0 then
-				Con := DEP_CARTESIAN@(L,dep);
-				Pos_Con := DEP_CARTESIAN@(L_Pos,dep);
+				Con := Fr.DEP_CARTESIAN(L,dep);
+				Pos_Con := Fr.DEP_CARTESIAN(L_Pos,dep);
 				for i in [1..Size(Con)] do #Now possable Conjugators.
 					c:= Product([1..Size(Pos_Con[i])],x->(quo(Con[i][x][1])*B[Pos_Con[i][x]]*quo(Con[i][x][3]))^Embedding(BS.wreath,x));
-					c:= (c*p^Embedding(BS.wreath,Size(Alph)+1))^BS.epi;;	
+					c:= (c*p^Embedding(BS.wreath,Size(Alph)+1))^BS.epi;;
 					if c <> fail then #Con is a valid element with representative c;
 						Info(InfoFR,3,"Computing g,h=",Name(g),",",Name(h),"     Conjugator found. Add to conjugator tuple ");
-						CT[Position(B,c)] := MEALY_FROM_STATES@(Con[i],p);
+						CT[Position(B,c)] := Fr.MEALY_FROM_STATES(Con[i],p);
 						#CT[Position(B,c)] := FRElement([Con[i]],[p],[1]);
 					fi;
-				od;	
+				od;
 			fi;
 		od;
 		AddDictionary(Con_dic,[g,h],CT); #Save work in case is it again asked for a CT for (g,h).
-		return CT;				
+		return CT;
 	end;
 	return Conjugators_branch_rek(g,h);
 end);
@@ -883,12 +883,12 @@ end);
 ##################################################################
 InstallOtherMethod(RepresentativeActionOp,
 	"Computes a conjugator in the given Branch group ",
-	[ IsBranched and IsFinitelyGeneratedGroup,IsFRElement,IsFRElement,IsFunction], 
+	[ IsBranched and IsFinitelyGeneratedGroup,IsFRElement,IsFRElement,IsFunction],
 	function(G,g,h,f)
 		local con;
 		if f <> OnPoints then TryNextMethod(); fi;
 		Info(InfoFR,2,"Try method for branch groups.");
-		con := CONJUGATORS_BRANCH@(G,g,h);
+		con := Fr.CONJUGATORS_BRANCH(G,g,h);
 		if con <> fail then
 			if Size(con)>0 then
 				return Representative(con);
@@ -900,11 +900,11 @@ InstallOtherMethod(RepresentativeActionOp,
 		end);
 InstallMethod(IsConjugate,
 	"For Branch Groups",
-	[ IsBranched and IsFinitelyGeneratedGroup,IsFRElement,IsFRElement], 
+	[ IsBranched and IsFinitelyGeneratedGroup,IsFRElement,IsFRElement],
   function(G,g,h)
   	local con;
 		Info(InfoFR,2,"Try method for branch groups.");
-  	con := CONJUGATORS_BRANCH@(G,g,h);
+  	con := Fr.CONJUGATORS_BRANCH(G,g,h);
 		if con <> fail then
 			if Size(con)>0 then
 				return true;
@@ -913,7 +913,7 @@ InstallMethod(IsConjugate,
 		fi;
 		Info(InfoFR,2,"Doesn't work. Try next...");
 		TryNextMethod();
-		end);	
+		end);
 
 
 #############################Example##############################
@@ -924,7 +924,7 @@ InstallMethod(IsConjugate,
 #				Branchstructure:=BranchStructure(GrigorchukGroup),
 #				RepSystem:=List(~.Branchstructure.group,x->PreImagesRepresentativeNC(~.Branchstructure.quo,x)))
 #	 );
-#CallFuncList(function(a,b,c,d) 
+#CallFuncList(function(a,b,c,d)
 #							local G,D,g,h;
 #							G:= GrigorchukGroup;
 #							D:= FRBranchGroupConjugacyData(G).initial_conj_dic;
@@ -941,13 +941,13 @@ InstallMethod(IsConjugate,
 #							AddDictionary(D,[d,d],[One(G),,,a*d*a*d,b,,,b*a*d*a*d,c,,,b*a*d*a,d,,,a*d*a]);
 #						end,GeneratorsOfGroup(GrigorchukGroup)
 #		);
-		
+
 #SetFRBranchGroupConjugacyData(GuptaSidkiGroup,
 #	 rec(	initial_conj_dic:=NewDictionary([One(GuptaSidkiGroup),One(GuptaSidkiGroup)],true),
 #				Branchstructure:=BranchStructure(GuptaSidkiGroup),
 #				RepSystem:=List(~.Branchstructure.group,x->PreImagesRepresentativeNC(~.Branchstructure.quo,x)))
 #	 );
-#CallFuncList(function(a,t) 
+#CallFuncList(function(a,t)
 #							local G,D,g,h;
 #							G:= GuptaSidkiGroup;
 #							D:= FRBranchGroupConjugacyData(G).initial_conj_dic;
@@ -971,31 +971,31 @@ InstallMethod(IsConjugate,
 ###############     Algorithm for the         ##################*
 ###############       GrigorchukGroup         ##################*
 ################################################################*
-################################################################* 
+################################################################*
 #****************************************************************
-BindGlobal("GRIG_CON@",function(G,g,h)
+Fr.GRIG_CON := (function(G,g,h)
 local f,gw,hw,Gen,a, b, c, d, Fam, aw, dw, ae, be, ce, de, Alph, x_1, x_2, K_repr, K_repr_words, D, ConTup_a, Check, alternating_a_form, shorten_word, compute_conjugates, compute_conjugates_of_word, L_Decomp, Compute_K_rep, L_word_to_Grig, Merge_Ls, conjugators_grig_rek, Res, r, Join_to_first;
 
 ############   Spare Computing Time in trivial case.     #########
  	if AlphabetOfFRSemigroup(G) <> AlphabetOfFRObject(g) or AlphabetOfFRSemigroup(G) <> AlphabetOfFRObject(h) then
 		return fail;
 	fi;
-	if g = h then 
-	 return One(G); 
-	fi;	
+	if g = h then
+	 return One(G);
+	fi;
 ############       (Local) GLOBALS           #####################
 	f := EpimorphismFromFreeGroup(G);
 	gw:=PreImagesRepresentativeNC(f,g);
 	hw:=PreImagesRepresentativeNC(f,h);
-	
+
 	Gen := GeneratorsOfGroup(G);
-	a:= Position(Gen,MealyElement([[4,2],[4,3],[5,1],[5,5],[5,5]],[(),(),(),(1,2),()],4));	
-	b:= Position(Gen,MealyElement([[4,2],[4,3],[5,1],[5,5],[5,5]],[(),(),(),(1,2),()],1));	
-	c:= Position(Gen,MealyElement([[4,2],[4,3],[5,1],[5,5],[5,5]],[(),(),(),(1,2),()],2));	
-	d:= Position(Gen,MealyElement([[4,2],[4,3],[5,1],[5,5],[5,5]],[(),(),(),(1,2),()],3));	
-	Fam := FamilyObj(gw);		
+	a:= Position(Gen,MealyElement([[4,2],[4,3],[5,1],[5,5],[5,5]],[(),(),(),(1,2),()],4));
+	b:= Position(Gen,MealyElement([[4,2],[4,3],[5,1],[5,5],[5,5]],[(),(),(),(1,2),()],1));
+	c:= Position(Gen,MealyElement([[4,2],[4,3],[5,1],[5,5],[5,5]],[(),(),(),(1,2),()],2));
+	d:= Position(Gen,MealyElement([[4,2],[4,3],[5,1],[5,5],[5,5]],[(),(),(),(1,2),()],3));
+	Fam := FamilyObj(gw);
 ##################################################################
-	aw :=AssocWordByLetterRep(Fam,[a]);  
+	aw :=AssocWordByLetterRep(Fam,[a]);
 	dw :=AssocWordByLetterRep(Fam,[d]);
 	ae := ImageElm(f,AssocWordByLetterRep(Fam,[a]));
 	be := ImageElm(f,AssocWordByLetterRep(Fam,[b]));
@@ -1009,13 +1009,13 @@ local f,gw,hw,Gen,a, b, c, d, Fam, aw, dw, ae, be, ce, de, Alph, x_1, x_2, K_rep
 #[[],a,ad,ada,adad,adada,adadada,adadada,b,ba,bad,bada,badad,badada,badadad,badadada]
 	K_repr := [[],[a],[a,d],[a,d,a],[a,d,a,d],[a,d,a,d,a],[a,d,a,d,a,d],[a,d,a,d,a,d,a],[b],[b,a],[b,a,d],[b,a,d,a],[b,a,d,a,d],[b,a,d,a,d,a],[b,a,d,a,d,a,d],[b,a,d,a,d,a,d,a]];
 	K_repr_words := List(K_repr,x->AssocWordByLetterRep(Fam,x));
-	
+
 	#Precomputed words, which decompose to the K_repr.: <K_repr[i]·l,f(K_repr[i])·l'> = D[i]·<l,l'>
 	D:= List([[],[c],[c,a,c,a],[c,a,c,a,c],[c,a,c,a,c,a,c,a],[c,a,c,a,c,a,c,a,c],[c,a,c,a,c,a,c,a,c,a,c,a],[c,a,c,a,c,a,c,a,c,a,c,a,c],[a,d,a],[a,d,a,c],[a,d,a,c,a,c,a],[a,d,a,c,a,c,a,c],[a,d,a,c,a,c,a,c,a,c,a],[a,d,a,c,a,c,a,c,a,c,a,c],[a,d,a,c,a,c,a,c,a,c,a,c,a,c,a],[a,d,a,c,a,c,a,c,a,c,a,c,a,c,a,c]],x->AssocWordByLetterRep(Fam,x));
 # %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 # %%%%%%%%%%%%%%%%%%        Functions       %%%%%%%%%%%%%%%%%%%%%%%
-# %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%	
-	
+# %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+
 	#TeporaryDebug function to locate possable errors.
 	Check := function(s,g,h,C)
 		local c;
@@ -1030,10 +1030,10 @@ local f,gw,hw,Gen,a, b, c, d, Fam, aw, dw, ae, be, ce, de, Alph, x_1, x_2, K_rep
 		fi;
 		return true;
 	end;
-	
+
 # %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 # %%%%%%%%%%%%%%%%%%%%     Magic on words     %%%%%%%%%%%%%%%%%%%%%
-# %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%	
+# %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 
 	#Given a word w in Generators of Grig, computes the form w= (a) x1 a x2 a x3… where xi in b,c,d
 	alternating_a_form := function(w)
@@ -1052,7 +1052,7 @@ local f,gw,hw,Gen,a, b, c, d, Fam, aw, dw, ae, be, ce, de, Alph, x_1, x_2, K_rep
 						last:=5;
 						last_ind:=-1;
 						change:= true;
-					else 
+					else
 						L := [b,c,d];
 						if (not last in [a,5]) and red_L[i] in L then
 							Remove(L,Position(L,last));
@@ -1066,7 +1066,7 @@ local f,gw,hw,Gen,a, b, c, d, Fam, aw, dw, ae, be, ce, de, Alph, x_1, x_2, K_rep
 							last_ind:=i;
 						fi;
 					fi;
-				fi;	
+				fi;
 			od;
 		od;
 		#Fill the gaps
@@ -1079,7 +1079,7 @@ local f,gw,hw,Gen,a, b, c, d, Fam, aw, dw, ae, be, ce, de, Alph, x_1, x_2, K_rep
 #-----------------------------------------------------------------
 
 	#Shortens a given Letter-word over Generators of L by killing all instances of x,-x and 1,1 and 2,2, -1,-1,-2,-2
-	shorten_word := function(w) 
+	shorten_word := function(w)
 		local change, last_pos, l, new_w;
 		change := true;
 		last_pos := Size(w)+1;
@@ -1087,7 +1087,7 @@ local f,gw,hw,Gen,a, b, c, d, Fam, aw, dw, ae, be, ce, de, Alph, x_1, x_2, K_rep
 		while change do
 			last_pos := Size(w);
 			change := false;
-			for l in [1..Size(w)-1] do 
+			for l in [1..Size(w)-1] do
 				if IsBound(w[l]) then
 					if w[l] = -1*(w[last_pos]) or (w[l]= w[last_pos] and w[l] in [-2,-1,1,2]) then
 						change := true;
@@ -1101,14 +1101,14 @@ local f,gw,hw,Gen,a, b, c, d, Fam, aw, dw, ae, be, ce, de, Alph, x_1, x_2, K_rep
 			od;
 		od;
 		new_w:=[];
-		for l in w do		
+		for l in w do
 			Add(new_w,l);
 		od;
 		return new_w{[1..Size(new_w)-1]};
 	end;
 #-----------------------------------------------------------------
 	#Given a generator gen of L and a Letter-word w in Grig, computes the gen^w in generators of L
-	compute_conjugates := function(gen,w) 
+	compute_conjugates := function(gen,w)
 		local gen_conjugates, Gen, x, g, L;
 		#Precomputed list gen_conjugates[x][y] is x^y as word in L_gen
 		#where L_gen = [[b],[a,b,a],[b,a,d,a,b,a,d,a],[a,b,a,d,a,b,a,d]];
@@ -1119,25 +1119,25 @@ local f,gw,hw,Gen,a, b, c, d, Fam, aw, dw, ae, be, ce, de, Alph, x_1, x_2, K_rep
 		gen_conjugates[1][b] := [1];
 		gen_conjugates[1][c] := [1];
 		gen_conjugates[1][d] := [1];
-		
+
 		gen_conjugates[2]  := [];
 		gen_conjugates[2][a] := [1];
 		gen_conjugates[2][b] := [1,2,1];
 		gen_conjugates[2][c] := [1,-4,2,1];
 		gen_conjugates[2][d] := [-4,2];
-		
+
 		gen_conjugates[3]  := [];
 		gen_conjugates[3][a] := [4];
 		gen_conjugates[3][b] := [1,3,1];
 		gen_conjugates[3][c] := [-3];
 		gen_conjugates[3][d] := [1,-3,1];
-		
+
 		gen_conjugates[4]  := [];
 		gen_conjugates[4][a] := [3];
 		gen_conjugates[4][b] := [1,4,1];
 		gen_conjugates[4][c] := [1,-4,1];
 		gen_conjugates[4][d] := [-4];
-		
+
 		#gen_conjugates := [[[1],[1],[1],[2]],
 		#										[[1,2,1],[1,-4,2,1],[-4,2],[1]],
 		#										[[1,3,1],[-3],[1,-3,1],[4]],
@@ -1148,7 +1148,7 @@ local f,gw,hw,Gen,a, b, c, d, Fam, aw, dw, ae, be, ce, de, Alph, x_1, x_2, K_rep
 			for g in Gen do
 				if g<0 then
 					Append(L,List(Reversed(gen_conjugates[-1*g][x]),y->-1*y));
-				else 
+				else
 					Append(L,gen_conjugates[g][x]);
 				fi;
 			od;
@@ -1168,7 +1168,7 @@ local f,gw,hw,Gen,a, b, c, d, Fam, aw, dw, ae, be, ce, de, Alph, x_1, x_2, K_rep
 	end;
 #-----------------------------------------------------------------
 	#Given a word w in Generators of Grig computes a unique representative of w·L and the corresponding word in Letters
-	#of generators of L. 
+	#of generators of L.
 	#The resulting representative is an element of K_repr_words{[1..8]}
 	L_Decomp := function(w)
 		local l_elm,l_elm_compl,k,l,i,L,red_L,new_L,change,gen_conjugates;
@@ -1188,7 +1188,7 @@ local f,gw,hw,Gen,a, b, c, d, Fam, aw, dw, ae, be, ce, de, Alph, x_1, x_2, K_rep
 					change := true;
 					Add(l_elm,Reversed(new_L));
 					Add(new_L,d);
-				else 
+				else
 					Add(new_L,red_L[i]);
 				fi;
 			od;
@@ -1200,7 +1200,7 @@ local f,gw,hw,Gen,a, b, c, d, Fam, aw, dw, ae, be, ce, de, Alph, x_1, x_2, K_rep
 			Append(l_elm_compl,compute_conjugates(1,l));
 		od;
 		#Force the form unique beginning with a.
-		if Length(w)>7 then 
+		if Length(w)>7 then
 			w:=Subword(w,1,Length(w) mod 8);
 		fi;
 		if Length(w)>0 and Subword(w,1,1) = AssocWordByLetterRep(Fam,[d]) then
@@ -1227,7 +1227,7 @@ local f,gw,hw,Gen,a, b, c, d, Fam, aw, dw, ae, be, ce, de, Alph, x_1, x_2, K_rep
 				elif l = c then
 					nb := nb +1;
 					Add(new_L,d);
-				else 
+				else
 					Add(new_L,l);
 				fi;
 			od;
@@ -1235,15 +1235,15 @@ local f,gw,hw,Gen,a, b, c, d, Fam, aw, dw, ae, be, ce, de, Alph, x_1, x_2, K_rep
 			if IsOddInt(nb) then
 				w := AssocWordByLetterRep(Fam,[b])*w;
 				b_exist := true;
-			else 
+			else
 				b_exist := false;
 			fi;
 		od;
-		#Force the word to begin with a (after the possable b) to gain a unique form.	
+		#Force the word to begin with a (after the possable b) to gain a unique form.
 		if b_exist then
 			w := Subword(w,2,Length(w));
 		fi;
-		if Length(w)>7 then 
+		if Length(w)>7 then
 			w:=Subword(w,1,Length(w) mod 8);
 		fi;
 		if Length(w)>0 and Subword(w,1,1) = AssocWordByLetterRep(Fam,[d]) then
@@ -1273,8 +1273,8 @@ local f,gw,hw,Gen,a, b, c, d, Fam, aw, dw, ae, be, ce, de, Alph, x_1, x_2, K_rep
 
 # %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 # %%%%%%%%%%%%%%%%%   Helping Functions    %%%%%%%%%%%%%%%%%%%%%%%%
-# %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%	
-	#Computes the conjugator tuple for the pair (g,a): 
+# %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+	#Computes the conjugator tuple for the pair (g,a):
 	ConTup_a := function (g)
 		local g1_modL,l,Allowed_reps,Connected_conjs,con_at_1,con_word,con,Centr_a,Con_tuple;
 		if IsOne(Activity(g)) then
@@ -1284,7 +1284,7 @@ local f,gw,hw,Gen,a, b, c, d, Fam, aw, dw, ae, be, ce, de, Alph, x_1, x_2, K_rep
 			return [];
 		fi;
 		#L_gen := [[b],[a,b,a],[b,a,d,a,b,a,d,a],[a,b,a,d,a,b,a,d]];
-		g1_modL:=L_Decomp(PreImagesRepresentativeNC(f,State(g,1))); 
+		g1_modL:=L_Decomp(PreImagesRepresentativeNC(f,State(g,1)));
 		l:=g1_modL[2];
 		g1_modL:=LetterRepAssocWord(g1_modL[1]);
 		#See Lemma lem:conjugators_of_a for Details
@@ -1306,13 +1306,13 @@ local f,gw,hw,Gen,a, b, c, d, Fam, aw, dw, ae, be, ce, de, Alph, x_1, x_2, K_rep
 		Con_tuple:= [];
 		for con in Centr_a do
 			Con_tuple[Position(K_repr,LetterRepAssocWord(Compute_K_rep(con)))] := ImageElm(f,con);
-		od;	
+		od;
 		Check("ConTup_a",g,ae,Con_tuple);
 		return Con_tuple;
-	end;	
+	end;
 	#Finds all Elements <l1,l2> with <l1,l2> in Grig, for l1 in L1, l2 in L2 and return result as Conjugator tuple.
 	Merge_Ls := function(L1,L2,with_action)
-		local aw_w,aw_t,dw_w,res_Con,i,x;	
+		local aw_w,aw_t,dw_w,res_Con,i,x;
 		aw_w := One(aw);
 		aw_t := ();
 		dw_w := One(dw);
@@ -1339,7 +1339,7 @@ local f,gw,hw,Gen,a, b, c, d, Fam, aw, dw, ae, be, ce, de, Alph, x_1, x_2, K_rep
 						if L1[i]=ImageElm(f,K_repr_words[i]) and L2[x]=ImageElm(f,K_repr_words[x]) then
 							res_Con[Position(K_repr_words,Compute_K_rep(dw_w*D[i]*aw_w))] := ImageElm(f,dw_w*D[i]*aw_w);
 						else #Could always compute the words as generators, but seems uneccassary
-							res_Con[Position(K_repr_words,Compute_K_rep(dw_w*D[i]*aw_w))] := MEALY_FROM_STATES@([L1[i],L2[x]],aw_t);
+							res_Con[Position(K_repr_words,Compute_K_rep(dw_w*D[i]*aw_w))] := Fr.MEALY_FROM_STATES([L1[i],L2[x]],aw_t);
 						fi;
 					fi;
 				od;
@@ -1355,7 +1355,7 @@ local f,gw,hw,Gen,a, b, c, d, Fam, aw, dw, ae, be, ce, de, Alph, x_1, x_2, K_rep
 				L[i] := K[i];
 			fi;
 		od;
-	end;		
+	end;
 # %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 # %%%%%%%%%%%%%%%%%%     Main Computor      %%%%%%%%%%%%%%%%%%%%%%%
 # %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
@@ -1399,7 +1399,7 @@ local f,gw,hw,Gen,a, b, c, d, Fam, aw, dw, ae, be, ce, de, Alph, x_1, x_2, K_rep
 			if Size(L1) > 0 then
 				L2 := conjugators_grig_rek(State(g,x_2),State(h,x_2));
 				res_Con := Merge_Ls(L1,L2,false);
-			fi;		
+			fi;
 
 			#Test for Conjugator with non-trivial Activity
 			L1 := conjugators_grig_rek(State(g,x_1),State(h,x_2));
@@ -1420,7 +1420,7 @@ local f,gw,hw,Gen,a, b, c, d, Fam, aw, dw, ae, be, ce, de, Alph, x_1, x_2, K_rep
 			if Size(L1) > 0 then
 				L2 := conjugators_grig_rek(State(g,x_2),State(h,x_2));
 				res_Con := Merge_Ls(L1,L2,false);
-			fi;	
+			fi;
 			#Test for Conjugator with non-trivial Activity
 			L1 := conjugators_grig_rek(State(g,x_1),State(h,x_2));
 			L2 := conjugators_grig_rek(State(g,x_2),State(h,x_1));
@@ -1468,7 +1468,7 @@ local f,gw,hw,Gen,a, b, c, d, Fam, aw, dw, ae, be, ce, de, Alph, x_1, x_2, K_rep
 			return res_Con;
 		fi;
 	end;
-	
+
 	Res:= conjugators_grig_rek(g,h);
 	Info(InfoFR,3,"Result of recursive computation: ",Res,"\n");
 	if Size(Res) = 0 then
@@ -1476,28 +1476,26 @@ local f,gw,hw,Gen,a, b, c, d, Fam, aw, dw, ae, be, ce, de, Alph, x_1, x_2, K_rep
 	fi;
 	return Representative(Res);
 end);
-SetFRConjugacyAlgorithm(GrigorchukGroup,GRIG_CON@);
+SetFRConjugacyAlgorithm(GrigorchukGroup,Fr.GRIG_CON);
 #################################################################
 # %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%#
 # %%%%%%%%%%%%%%%%%%%%      IsConjugate        %%%%%%%%%%%%%%%%%%#
 # %%%%%%%%%%%%%%%%%%%%	 RepresentativeActionOp %%%%%%%%%%%%%%%%%%#
 # %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%#
-#################################################################	
+#################################################################
 InstallMethod(IsConjugate,
 	" For FR groups with optimized conjugacy algorithm ",
-	[ IsFRGroup and HasFRConjugacyAlgorithm,IsFRElement,IsFRElement], 
+	[ IsFRGroup and HasFRConjugacyAlgorithm,IsFRElement,IsFRElement],
   function(G,a,b)
   	return FRConjugacyAlgorithm(G)(G,a,b) <> fail;
  	end);
 InstallOtherMethod(RepresentativeActionOp,
  " For FR groups with optimized conjugacy algorithm ",
-	[ IsFRGroup and HasFRConjugacyAlgorithm,IsFRElement,IsFRElement,IsFunction], 
+	[ IsFRGroup and HasFRConjugacyAlgorithm,IsFRElement,IsFRElement,IsFunction],
   function(G,a,b,f)
   	if f <> OnPoints then TryNextMethod(); fi;
   	return FRConjugacyAlgorithm(G)(G,a,b);
  	end);
- 	
-  
 
 
 
@@ -1513,11 +1511,13 @@ InstallOtherMethod(RepresentativeActionOp,
 
 
 
-	
-	
-	
-	
-	
+
+
+
+
+
+
+
 
 
 

--- a/gap/examples.gi
+++ b/gap/examples.gi
@@ -11,7 +11,7 @@
 ##
 #############################################################################
 
-BindGlobal("SETGENERATORNAMES@", function(G,n)
+Fr.SETGENERATORNAMES := ( function(G,n)
     local i;
     for i in [1..Length(n)] do
         if IsGroup(G) then
@@ -24,7 +24,7 @@ BindGlobal("SETGENERATORNAMES@", function(G,n)
     od;
 end);
 
-BindGlobal("LPGROUPIMAGE@", function(G,F,Ggens,Fgens,Sgens,Scoord)
+Fr.LPGROUPIMAGE := ( function(G,F,Ggens,Fgens,Sgens,Scoord)
     local knows, Gtop, Ftop, Ptop, init, recur, bootstrap;
 
     bootstrap := true;
@@ -36,7 +36,7 @@ BindGlobal("LPGROUPIMAGE@", function(G,F,Ggens,Fgens,Sgens,Scoord)
         if p<>fail then return p; fi;
         if KnowsDictionary(seen,g) then
             if bootstrap then
-                AddDictionary(knows,g,MAPPEDWORD@(ShortGroupWordInSet(Group(Ggens),g,infinity)[2],Fgens));
+                AddDictionary(knows,g,Fr.MAPPEDWORD(ShortGroupWordInSet(Group(Ggens),g,infinity)[2],Fgens));
                 Info(InfoFR,3,"Added ",g,"=",LookupDictionary(knows,g));
             fi;
             # we reached a recurring state not yet known
@@ -46,7 +46,7 @@ BindGlobal("LPGROUPIMAGE@", function(G,F,Ggens,Fgens,Sgens,Scoord)
         w := Position(Ptop,ActivityPerm(g));
         if w=fail then return fail; fi; # even activity is impossible
         w := Ftop[w];
-        h := LeftQuotient(MAPPEDWORD@(w,Ggens),g);
+        h := LeftQuotient(Fr.MAPPEDWORD(w,Ggens),g);
         todoh := [];
         while not IsOne(h) do
             if h in todoh then return fail; fi; # stuck in a loop
@@ -63,10 +63,10 @@ BindGlobal("LPGROUPIMAGE@", function(G,F,Ggens,Fgens,Sgens,Scoord)
             p := PositionProperty(Ptop,s->p^s=Scoord);
             x := recur(State(h^Gtop[p],Scoord),seen);
             if x=fail then return fail; fi;
-            x := MAPPEDWORD@(x,Sgens)^(Ftop[p]^-1);
+            x := Fr.MAPPEDWORD(x,Sgens)^(Ftop[p]^-1);
             w := w*x;
-            h := LeftQuotient(MAPPEDWORD@(x,Ggens),h);
-            Assert(1,MAPPEDWORD@(w,Ggens)*h=g);
+            h := LeftQuotient(Fr.MAPPEDWORD(x,Ggens),h);
+            Assert(1,Fr.MAPPEDWORD(w,Ggens)*h=g);
         od;
         AddDictionary(knows,g,w);
         return w;
@@ -81,9 +81,9 @@ BindGlobal("LPGROUPIMAGE@", function(G,F,Ggens,Fgens,Sgens,Scoord)
         Ptop := AsList(TopVertexTransformations(G));
         Ftop := [];
         for x in Ptop do
-            Add(Ftop,MAPPEDWORD@(ShortGroupWordInSet(Group(Ggens),g->ActivityPerm(g)=x,infinity)[2],Fgens));
+            Add(Ftop,Fr.MAPPEDWORD(ShortGroupWordInSet(Group(Ggens),g->ActivityPerm(g)=x,infinity)[2],Fgens));
         od;
-        Gtop := List(Ftop,x->MAPPEDWORD@(x,Ggens));
+        Gtop := List(Ftop,x->Fr.MAPPEDWORD(x,Ggens));
 
         todo := NewFIFO(TransposedMat([Ggens,Fgens]));
         for x in todo do
@@ -101,7 +101,7 @@ BindGlobal("LPGROUPIMAGE@", function(G,F,Ggens,Fgens,Sgens,Scoord)
             fi;
         od;
         bootstrap := false;
-    end;	
+    end;
 
     return function(g)
         if bootstrap then init(); fi;
@@ -109,7 +109,7 @@ BindGlobal("LPGROUPIMAGE@", function(G,F,Ggens,Fgens,Sgens,Scoord)
     end;
 end);
 
-BindGlobal("LPGROUPPREIMAGE@", function(Fgens,Sgens,Ggens,depth,Scoord)
+Fr.LPGROUPPREIMAGE := ( function(Fgens,Sgens,Ggens,depth,Scoord)
     local Sletter;
 
     Sletter := Length(Ggens)+1;
@@ -138,9 +138,9 @@ BindGlobal("LPGROUPPREIMAGE@", function(Fgens,Sgens,Ggens,depth,Scoord)
                 else
                     i := Fgens[AbsInt(i)];
                     for j in [1..up] do
-                        i := MAPPEDWORD@(i,Sgens);
+                        i := Fr.MAPPEDWORD(i,Sgens);
                     od;
-                    g := g*MAPPEDWORD@(i,Ggens);
+                    g := g*Fr.MAPPEDWORD(i,Ggens);
                 fi;
             od;
             if up<>down then
@@ -153,7 +153,7 @@ BindGlobal("LPGROUPPREIMAGE@", function(Fgens,Sgens,Ggens,depth,Scoord)
             return g;
         end;
     else
-        return w->MAPPEDWORD@(w,Ggens);
+        return w->Fr.MAPPEDWORD(w,Ggens);
     fi;
 end);
 
@@ -326,14 +326,14 @@ BindGlobal("GrigorchukMachine",
 BindGlobal("GrigorchukGroup",SCGroup(GrigorchukMachine));
 SetName(GrigorchukGroup,"GrigorchukGroup");
 
-SETGENERATORNAMES@(GrigorchukGroup,["a","b","c","d"]);
+Fr.SETGENERATORNAMES(GrigorchukGroup,["a","b","c","d"]);
 CallFuncList(function(a,b,c,d)
     local x;
     x := Comm(a,b);
     SetBranchingSubgroup(GrigorchukGroup,Group(x,x^c,x^(c*a)));
 end, GeneratorsOfGroup(GrigorchukGroup));
-        
-BindGlobal("ITERATEMAP@", function(s,n,w)
+
+Fr.ITERATEMAP := ( function(s,n,w)
     local r, i;
     r := [w];
     for i in [1..n] do
@@ -343,7 +343,7 @@ BindGlobal("ITERATEMAP@", function(s,n,w)
     return r;
 end);
 
-BindGlobal("GRIGP_IMAGE@", function(nuke,nukeimg,Fgens,Sgens,tau,reduce)
+Fr.GRIGP_IMAGE := ( function(nuke,nukeimg,Fgens,Sgens,tau,reduce)
     local image, knows, i;
     knows := NewDictionary(nuke[1],true);
     for i in [1..Length(nuke)] do
@@ -368,8 +368,8 @@ BindGlobal("GRIGP_IMAGE@", function(nuke,nukeimg,Fgens,Sgens,tau,reduce)
             if not IsOne(tau(y)) then return fail; fi;
             y := recur(y);
             if y=fail then return fail; fi;
-            x := MAPPEDWORD@(x,Sgens)*Fgens[1]*MAPPEDWORD@(y,Sgens);
-            if ISONE@(i[2]) then x:=x*Fgens[1]; fi;
+            x := Fr.MAPPEDWORD(x,Sgens)*Fgens[1]*Fr.MAPPEDWORD(y,Sgens);
+            if Fr.ISONE(i[2]) then x:=x*Fgens[1]; fi;
             x := reduce(x);
             AddDictionary(knows,g,x);
             return x;
@@ -395,8 +395,8 @@ SetFRGroupPreImageData(GrigorchukGroup, function(depth)
         rels := [a^2,b^2,c^2,d^2,b*c*d,(a*d)^4,(a*d*a*c*a*c)^4];
         if depth>=0 then
             F := F / Concatenation(rels{[1..5]},
-                         ITERATEMAP@(s,depth+1,rels[6]),
-                         ITERATEMAP@(s,depth,rels[7]));
+                         Fr.ITERATEMAP(s,depth+1,rels[6]),
+                         Fr.ITERATEMAP(s,depth,rels[7]));
             creator := ElementOfFpGroup;
         else
             F := LPresentedGroup(F,[],[s],rels);
@@ -448,15 +448,15 @@ SetFRGroupPreImageData(GrigorchukGroup, function(depth)
     nukeimg := [One(F),F.1,F.2,F.3,F.4];
     SortParallel(nuke,nukeimg);
     return rec(F:=F,
-               image:=GRIGP_IMAGE@(nuke,nukeimg,Fgens,Sgens,tau,reduce),
-               preimage:=LPGROUPPREIMAGE@(Fgens,Sgens,Ggens,depth,2),
+               image:=Fr.GRIGP_IMAGE(nuke,nukeimg,Fgens,Sgens,tau,reduce),
+               preimage:=Fr.LPGROUPPREIMAGE(Fgens,Sgens,Ggens,depth,2),
                reduce:=reduce);
 end);
 
 BindGlobal("GrigorchukOverGroup", MixerGroup(Group((1,2)),Group((1,2)),
         [[IdentityMapping(Group((1,2)))],[],[]]));
 SetName(GrigorchukOverGroup,"GrigorchukOverGroup");
-SETGENERATORNAMES@(GrigorchukOverGroup,["a","bb","cc","dd"]);
+Fr.SETGENERATORNAMES(GrigorchukOverGroup,["a","bb","cc","dd"]);
 
 # growth of PermGroup(GrigorchukOverGroup,5), generated by nucleus, is
 # [1, 8, 14, 56, 89, 248, 416, 1160, 1804, 3816, 5871, 13400, 20344, 42248, 64020, 134072, 189600, 317984, 445352, 786144, 1066211, 1700736, 2340722, 3767744, 4833667, 6942160, 9039846, 13509040, 17041513, 24065960, 31045388, 43791128, 39928094, 23152344, 19514220, 13313384, 7589784, 2289688, 1030745, 386408, 60027]
@@ -484,8 +484,8 @@ SetFRGroupPreImageData(GrigorchukOverGroup, function(depth)
         creator := ElementOfLpGroup;
     else
         F := F / Concatenation(rels{[1..7]},
-                     Concatenation(List(rels{[8..11]},x->ITERATEMAP@(s,depth+1,x))),
-                     Concatenation(List(rels{[12..14]},x->ITERATEMAP@(s,depth,x))));
+                     Concatenation(List(rels{[8..11]},x->Fr.ITERATEMAP(s,depth+1,x))),
+                     Concatenation(List(rels{[12..14]},x->Fr.ITERATEMAP(s,depth,x))));
         creator := ElementOfFpGroup;
     fi;
     tau := function(g)
@@ -535,15 +535,15 @@ SetFRGroupPreImageData(GrigorchukOverGroup, function(depth)
     nukeimg := [One(F),F.1,F.2,F.3,F.4,F.2*F.3,F.2*F.4,F.3*F.4,F.2*F.3*F.4];
     SortParallel(nuke,nukeimg);
     return rec(F:=F,
-               image:=GRIGP_IMAGE@(nuke,nukeimg,Fgens,Sgens,tau,reduce),
-               preimage:=LPGROUPPREIMAGE@(Fgens,Sgens,Ggens,depth,2),
+               image:=Fr.GRIGP_IMAGE(nuke,nukeimg,Fgens,Sgens,tau,reduce),
+               preimage:=Fr.LPGROUPPREIMAGE(Fgens,Sgens,Ggens,depth,2),
                reduce:=reduce);
 end);
 
 BindGlobal("GrigorchukTwistedTwin", SCGroup(MealyMachine(
         [[5,5],[3,1],[1,4],[5,2],[5,5]],
         [(1,2),(),(),(),()])));
-SETGENERATORNAMES@(GrigorchukTwistedTwin,["a","x","y","z"]);
+Fr.SETGENERATORNAMES(GrigorchukTwistedTwin,["a","x","y","z"]);
 SetFRGroupPreImageData(GrigorchukTwistedTwin, function(depth)
     local F, a, x, y, z, s, rels, Fgens, Ggens, Sgens;
 
@@ -571,7 +571,7 @@ SetFRGroupPreImageData(GrigorchukTwistedTwin, function(depth)
     elif depth=-1 then
         F := LPresentedGroup(F,[],[s],rels);
     else
-        F := F / Concatenation(List(rels,x->ITERATEMAP@(s,depth,x)));
+        F := F / Concatenation(List(rels,x->Fr.ITERATEMAP(s,depth,x)));
     fi;
     Fgens := GeneratorsOfGroup(F){[1..4]};
     if depth=-1 then
@@ -580,8 +580,8 @@ SetFRGroupPreImageData(GrigorchukTwistedTwin, function(depth)
         Sgens := List(Sgens,x->ElementOfFpGroup(FamilyObj(F.1),x));
     fi;
     return rec(F:=F,
-               image:=LPGROUPIMAGE@(GrigorchukTwistedTwin,F,Ggens,GeneratorsOfGroup(F){[1..4]},Sgens,2),
-               preimage:=LPGROUPPREIMAGE@(Fgens,Sgens,Ggens,depth,2),
+               image:=Fr.LPGROUPIMAGE(GrigorchukTwistedTwin,F,Ggens,GeneratorsOfGroup(F){[1..4]},Sgens,2),
+               preimage:=Fr.LPGROUPPREIMAGE(Fgens,Sgens,Ggens,depth,2),
                reduce:=w->w);
 end);
 GermData(GrigorchukTwistedTwin).init := function(data)
@@ -688,14 +688,14 @@ end);
 BindGlobal("AleshinMachine", AleshinMachines(3));
 BindGlobal("AleshinGroup", SCGroup(AleshinMachine)); # the main example
 AleshinGroup!.Name := "AleshinGroup";
-SETGENERATORNAMES@(AleshinGroup,["a","b","c"]);
+Fr.SETGENERATORNAMES(AleshinGroup,["a","b","c"]);
 
 BindGlobal("BabyAleshinMachine",
         MealyMachine([[2,3],[3,2],[1,1]],[(),(),(1,2)]));
 
 BindGlobal("BabyAleshinGroup", SCGroup(BabyAleshinMachine));
 SetName(BabyAleshinGroup,"BabyAleshinGroup");
-SETGENERATORNAMES@(BabyAleshinGroup,["a","b","c"]);
+Fr.SETGENERATORNAMES(BabyAleshinGroup,["a","b","c"]);
 
 BindGlobal("SidkiFreeGroup", FRGroup("a=<a^2,a^t>","t=<,t>(1,2)"));
 SetName(SidkiFreeGroup,"SidkiFreeGroup");
@@ -735,7 +735,7 @@ BindGlobal("BrunnerSidkiVieiraMachine",
 
 BindGlobal("BrunnerSidkiVieiraGroup", SCGroup(BrunnerSidkiVieiraMachine));
 SetName(BrunnerSidkiVieiraGroup,"BrunnerSidkiVieiraGroup");
-SETGENERATORNAMES@(BrunnerSidkiVieiraGroup,["tau","mu"]);
+Fr.SETGENERATORNAMES(BrunnerSidkiVieiraGroup,["tau","mu"]);
 SetFRGroupPreImageData(BrunnerSidkiVieiraGroup, function(depth)
     local F, rels, sigma, tau, lambda, mu, Fgens, Ggens, Sgens;
 
@@ -755,7 +755,7 @@ SetFRGroupPreImageData(BrunnerSidkiVieiraGroup, function(depth)
     else
         sigma := GroupHomomorphismByImagesNC(F,F,[tau,mu],Sgens);
         if depth>=0 then
-            F := F / Concatenation(List(rels,r->ITERATEMAP@(sigma,depth,r)));
+            F := F / Concatenation(List(rels,r->Fr.ITERATEMAP(sigma,depth,r)));
         else
             F := LPresentedGroup(F,[],[sigma],rels);
         fi;
@@ -768,8 +768,8 @@ SetFRGroupPreImageData(BrunnerSidkiVieiraGroup, function(depth)
         Sgens := List(Sgens,x->ElementOfFpGroup(FamilyObj(Representative(F)),x));
     fi;
     return rec(F:=F,
-               image:=LPGROUPIMAGE@(BrunnerSidkiVieiraGroup,F,Ggens,Fgens,Sgens,2),
-               preimage:=LPGROUPPREIMAGE@(Fgens,Sgens,Ggens,depth,2),
+               image:=Fr.LPGROUPIMAGE(BrunnerSidkiVieiraGroup,F,Ggens,Fgens,Sgens,2),
+               preimage:=Fr.LPGROUPPREIMAGE(Fgens,Sgens,Ggens,depth,2),
                reduce:=w->w);
 end);
 
@@ -824,27 +824,27 @@ end);
 InstallGlobalFunction(GuptaSidkiGroups, function(n)
     local G, a, t;
     G := SCGroup(GuptaSidkiMachines(n));
-    SETGENERATORNAMES@(G,["a","t"]);
+    Fr.SETGENERATORNAMES(G,["a","t"]);
     a := G.1; t := G.2;
     SetBranchingSubgroup(G,GroupByGenerators(ListX([0..n-1],[0..n-1],function(x,y) return Comm(a,t)^(a^x*t^y); end)));
     SetName(G,Concatenation("GuptaSidkiGroups(",String(n),")"));
     return G;
 end);
 
-BindGlobal("GUPTASIDKIGROUPIMAGE@", function(g,f,Ggens,Fgens,Sgens,Scoord)
+Fr.GUPTASIDKIGROUPIMAGE := ( function(g,f,Ggens,Fgens,Sgens,Scoord)
     local nuke, knows, x, y, Gtop, Ftop, Ptop, GENREDUCE;
 
     nuke := NucleusOfFRSemigroup(g);
     knows := NewDictionary(nuke[1],true);
     for x in nuke do
-        AddDictionary(knows,x,MAPPEDWORD@(ShortGroupWordInSet(Group(Ggens),x,infinity)[2],Fgens));
+        AddDictionary(knows,x,Fr.MAPPEDWORD(ShortGroupWordInSet(Group(Ggens),x,infinity)[2],Fgens));
     od;
     Ptop := AsList(TopVertexTransformations(g));
     Ftop := [];
     for x in Ptop do
-        Add(Ftop,MAPPEDWORD@(ShortGroupWordInSet(Group(Ggens),g->ActivityPerm(g)=x,infinity)[2],Fgens));
+        Add(Ftop,Fr.MAPPEDWORD(ShortGroupWordInSet(Group(Ggens),g->ActivityPerm(g)=x,infinity)[2],Fgens));
     od;
-    Gtop := List(Ftop,x->MAPPEDWORD@(x,Ggens));
+    Gtop := List(Ftop,x->Fr.MAPPEDWORD(x,Ggens));
     GENREDUCE := function(h,w)
         local n, i, j, x;
         n := NormOfBoundedFRElement(h);
@@ -872,7 +872,7 @@ BindGlobal("GUPTASIDKIGROUPIMAGE@", function(g,f,Ggens,Fgens,Sgens,Scoord)
             w := Position(Ptop,ActivityPerm(g));
             if w=fail then return fail; fi;
             w := Ftop[w];
-            h := LeftQuotient(MAPPEDWORD@(w,Ggens),g);
+            h := LeftQuotient(Fr.MAPPEDWORD(w,Ggens),g);
             while not IsOne(h) do
                 x := GENREDUCE(h,w);
                 if x<>fail then
@@ -888,10 +888,10 @@ BindGlobal("GUPTASIDKIGROUPIMAGE@", function(g,f,Ggens,Fgens,Sgens,Scoord)
                 p := PositionProperty(Ptop,s->p^s=Scoord);
                 x := recur(State(h^Gtop[p],Scoord));
                 if x=fail then return fail; fi;
-                x := MAPPEDWORD@(x,Sgens)^(Ftop[p]^-1);
+                x := Fr.MAPPEDWORD(x,Sgens)^(Ftop[p]^-1);
                 w := w*x;
-                h := LeftQuotient(MAPPEDWORD@(x,Ggens),h);
-                Assert(1,MAPPEDWORD@(w,Ggens)*h=g);
+                h := LeftQuotient(Fr.MAPPEDWORD(x,Ggens),h);
+                Assert(1,Fr.MAPPEDWORD(w,Ggens)*h=g);
             od;
             AddDictionary(knows,g,w);
             return w;
@@ -900,7 +900,7 @@ BindGlobal("GUPTASIDKIGROUPIMAGE@", function(g,f,Ggens,Fgens,Sgens,Scoord)
     end;
 end);
 
-BindGlobal("GUPTASIDKIFRDATA@", function(G,p,depth,fullgroup)
+Fr.GUPTASIDKIFRDATA := ( function(G,p,depth,fullgroup)
     local F, rels, rels0, sigma, a, t, tt, Fgens, Ggens, Sgens, creator,
           i, j, k, l, e, image;
 
@@ -946,7 +946,7 @@ BindGlobal("GUPTASIDKIFRDATA@", function(G,p,depth,fullgroup)
         fi;
 
         if depth>=0 then
-            F := F / Flat([rels0,List(rels,r->ITERATEMAP@(sigma,depth,r))]);
+            F := F / Flat([rels0,List(rels,r->Fr.ITERATEMAP(sigma,depth,r))]);
             creator := x->ElementOfFpGroup(FamilyObj(Representative(F)),x);
         elif fullgroup then
             F := LPresentedGroup(F,rels0,[sigma],rels);
@@ -964,8 +964,8 @@ BindGlobal("GUPTASIDKIFRDATA@", function(G,p,depth,fullgroup)
     Sgens := List(MappingGeneratorsImages(sigma)[2],creator);
     if fullgroup then
         return rec(F:=F,
-                   image:=GUPTASIDKIGROUPIMAGE@(G,F,Ggens,Fgens,Sgens,p),
-                   preimage:=LPGROUPPREIMAGE@(Ggens,Fgens,Sgens,depth,p),
+                   image:=Fr.GUPTASIDKIGROUPIMAGE(G,F,Ggens,Fgens,Sgens,p),
+                   preimage:=Fr.LPGROUPPREIMAGE(Ggens,Fgens,Sgens,depth,p),
                    reduce:=w->w);
     else
         return rec(F:=F);
@@ -977,7 +977,7 @@ InstallGlobalFunction(GeneralizedGuptaSidkiGroups, function(p)
     P := CyclicGroup(IsPermGroup,p);
     P := MixerMachine(P,P,[List([1..p-1],i->GroupHomomorphismByImages(P,P,[P.1],[P.1^i]))]);
     G := Group(FRElement(P,2),FRElement(P,p+1));
-    SETGENERATORNAMES@(G,["a","t"]);
+    Fr.SETGENERATORNAMES(G,["a","t"]);
     SetName(G,Concatenation("GeneralizedGuptaSidkiGroups(",String(p),")"));
     SetUnderlyingFRMachine(G,P);
     SetIsStateClosed(G,true);
@@ -986,9 +986,9 @@ InstallGlobalFunction(GeneralizedGuptaSidkiGroups, function(p)
 
     SetFRGroupPreImageData(G,function(depth)
         local r, s;
-        r := GUPTASIDKIFRDATA@(G,p,depth,true);
+        r := Fr.GUPTASIDKIFRDATA(G,p,depth,true);
         if depth=-1 then
-            s := GUPTASIDKIFRDATA@(G,p,depth,false);
+            s := Fr.GUPTASIDKIFRDATA(G,p,depth,false);
             SetEmbeddingOfAscendingSubgroup(r.F,GroupHomomorphismByImagesNC(
                     s.F,r.F,GeneratorsOfGroup(s.F),List([1..p],i->r.F.2^(r.F.1^(i-1)))));
         fi;
@@ -1070,7 +1070,7 @@ InstallGlobalFunction(NeumannGroup, function(P)
     local G, M;
     M := NeumannMachine(P);
     G := SCGroup(M);
-    SetName(G,Concatenation("NeumannGroup(",STRINGGROUP@(P),")"));
+    SetName(G,Concatenation("NeumannGroup(",Fr.STRINGGROUP(P),")"));
     G!.Correspondence := [GroupHomomorphismByImages(P,G,GeneratorsOfGroup(P),
       GeneratorsOfGroup(G){Correspondence(G){Correspondence(M)[1]}}),
     GroupHomomorphismByImages(P,G,GeneratorsOfGroup(P),
@@ -1082,7 +1082,7 @@ InstallGlobalFunction(FabrykowskiGuptaGroups, function(p)
     local G;
     G := NeumannGroup(CyclicGroup(IsPermGroup,p));
     G!.Name := Concatenation("FabrykowskiGuptaGroups(",String(p),")");
-    SETGENERATORNAMES@(G,["a","r"]);
+    Fr.SETGENERATORNAMES(G,["a","r"]);
     SetFRGroupPreImageData(G,function(depth)
         local F, rels, sigma, a, r, Fgens, Ggens, Sgens, j, k, l;
 
@@ -1115,7 +1115,7 @@ InstallGlobalFunction(FabrykowskiGuptaGroups, function(p)
         else
             sigma := GroupHomomorphismByImagesNC(F,F,[a,r[1]],Sgens);
             if depth>=0 then
-                F := F / Flat([rels[1],r[1]^p,List(rels{[2..Length(rels)]},r->ITERATEMAP@(sigma,depth,r))]);
+                F := F / Flat([rels[1],r[1]^p,List(rels{[2..Length(rels)]},r->Fr.ITERATEMAP(sigma,depth,r))]);
             else
                 F := LPresentedGroup(F,[],[sigma],rels);
             fi;
@@ -1128,8 +1128,8 @@ InstallGlobalFunction(FabrykowskiGuptaGroups, function(p)
             Sgens := List(Sgens,x->ElementOfFpGroup(FamilyObj(Representative(F)),x));
         fi;
         return rec(F:=F,
-                   image:=LPGROUPIMAGE@(G,F,Ggens,Fgens,Sgens,p),
-                   preimage:=LPGROUPPREIMAGE@(Ggens,Fgens,Sgens,depth,p),
+                   image:=Fr.LPGROUPIMAGE(G,F,Ggens,Fgens,Sgens,p),
+                   preimage:=Fr.LPGROUPPREIMAGE(Ggens,Fgens,Sgens,depth,p),
                    reduce:=w->w);
     end);
     return G;
@@ -1141,7 +1141,7 @@ FabrykowskiGuptaGroup!.Name := "FabrykowskiGuptaGroup";
 BindGlobal("ZugadiSpinalGroup", MixerGroup(Group((1,2,3)),Group((1,2,3)),
         [[IdentityMapping(Group((1,2,3))),IdentityMapping(Group((1,2,3)))]]));
 SetName(ZugadiSpinalGroup,"ZugadiSpinalGroup");
-SETGENERATORNAMES@(ZugadiSpinalGroup,["a","s"]);
+Fr.SETGENERATORNAMES(ZugadiSpinalGroup,["a","s"]);
 #############################################################################
 
 #############################################################################
@@ -1166,14 +1166,14 @@ InstallGlobalFunction(HanoiGroup, function(k)
     if k=3 then
         SetFRGroupPreImageData(G,function(depth)
             local F, Fgens, Ggens, Sgens, a, b, c, d, e, f, g, h, i, tau, rels;
-            
+
             if depth=infinity then
                 F := FreeGroup("a","b","c","tau");
                 tau := F.4;
             else
                 F := FreeGroup("a","b","c");
             fi;
-            
+
             a := F.1; b := F.2; c := F.3;
             d := Comm(a,b); e := Comm(b,c); f := Comm(c,a);
             g := d^c; h := e^a; i := f^b;
@@ -1187,7 +1187,7 @@ InstallGlobalFunction(HanoiGroup, function(k)
             else
                 tau := GroupHomomorphismByImagesNC(F,F,Fgens,Sgens);
                 if depth>=0 then
-                    F := F / Flat([rels{[1..3]},List(rels{[4..Length(rels)]},r->ITERATEMAP@(tau,depth,r))]);
+                    F := F / Flat([rels{[1..3]},List(rels{[4..Length(rels)]},r->Fr.ITERATEMAP(tau,depth,r))]);
                 else
                     F := LPresentedGroup(F,[],[tau],rels);
                 fi;
@@ -1200,8 +1200,8 @@ InstallGlobalFunction(HanoiGroup, function(k)
                 Sgens := List(Sgens,x->ElementOfFpGroup(FamilyObj(Representative(F)),x));
             fi;
             return rec(F:=F,
-                   image:=LPGROUPIMAGE@(G,F,Ggens,Fgens,Sgens,3),
-                   preimage:=LPGROUPPREIMAGE@(Ggens,Fgens,Sgens,depth,3),
+                   image:=Fr.LPGROUPIMAGE(G,F,Ggens,Fgens,Sgens,3),
+                   preimage:=Fr.LPGROUPPREIMAGE(Ggens,Fgens,Sgens,depth,3),
                    reduce:=w->w);
         end);
     fi;
@@ -1309,7 +1309,7 @@ InstallMethod(FRAffineGroup, "(FR) for a dimension, a ring, an element, a transv
             od;
             Add(trans,t);
             Add(out,o);
-            if not ISINVERTIBLE@(out[i]) then return fail; fi;
+            if not Fr.ISINVERTIBLE(out[i]) then return fail; fi;
             i := i+1;
             if RemInt(i,10)=0 then
                 Info(InfoFR, 2, "FRAffineGroup: at least ",i," states");
@@ -1334,7 +1334,7 @@ InstallGlobalFunction(CayleyGroup, function(g)
     s := GeneratorsOfGroup(m);
     id := First(s,x->ActivityPerm(x)=());
     m!.Correspondence := [GroupHomomorphismByImages(g,m,GeneratorsOfGroup(g),List(GeneratorsOfGroup(g),x->First(s,y->ActivityPerm(y)=(x^h)^-1)^-1*id)),id];
-    SetName(m,Concatenation("CayleyGroup(",STRINGGROUP@(g),")"));
+    SetName(m,Concatenation("CayleyGroup(",Fr.STRINGGROUP(g),")"));
     return m;
 end);
 
@@ -1357,7 +1357,7 @@ end);
 #E BinaryKneadingGroup
 #E BasilicaGroup
 ##
-BindGlobal("BINARYKNEADINGMACHINE@", function(arg)
+Fr.BINARYKNEADINGMACHINE := ( function(arg)
     local dbl, i, s, G, M, gen, act, h0, h1, k, n, ksym, transition, output, name, kseq, preperiod, period;
 
     if arg=[] then arg := ["*"]; fi;
@@ -1512,7 +1512,7 @@ BindGlobal("BINARYKNEADINGMACHINE@", function(arg)
     return [M,G,name];
 end);
 
-BindGlobal("PERIODICBKG_PREIMAGE@", function(G,depth)
+Fr.PERIODICBKG_PREIMAGE := ( function(G,depth)
     local a, s, t, kseq, i, j, n, d, epsilon, F, r, tau, image, knows,
           nuke, nukeimg, Ggens, Fgens, Sgens, preimage, makeSgens;
     kseq := KneadingSequence(G);
@@ -1579,10 +1579,10 @@ BindGlobal("PERIODICBKG_PREIMAGE@", function(G,depth)
         fi;
         for i in [2..n] do for j in [2..n] do
             if kseq[i-1]=kseq[j-1] then
-                Append(r,ITERATEMAP@(s,depth,Comm(a[i],a[j]^a[1])));
+                Append(r,Fr.ITERATEMAP(s,depth,Comm(a[i],a[j]^a[1])));
             else
-                Append(r,ITERATEMAP@(s,depth,Comm(a[i],a[j])));
-                Append(r,ITERATEMAP@(s,depth,Comm(a[i],a[j]^(a[1]^2))));
+                Append(r,Fr.ITERATEMAP(s,depth,Comm(a[i],a[j])));
+                Append(r,Fr.ITERATEMAP(s,depth,Comm(a[i],a[j]^(a[1]^2))));
             fi;
         od; od;
         if knows then
@@ -1633,7 +1633,7 @@ BindGlobal("PERIODICBKG_PREIMAGE@", function(G,depth)
                 y := recur(LeftQuotient(tau(i[1][1]),i[1][2]));
                 if x=fail or y=fail then return fail; fi;
                 x := x^t*a*y^t;
-                if ISONE@(i[2]) then x := x/a; fi;
+                if Fr.ISONE(i[2]) then x := x/a; fi;
                 AddDictionary(knows,g,x);
                 return x;
             end;
@@ -1702,7 +1702,7 @@ BindGlobal("PERIODICBKG_PREIMAGE@", function(G,depth)
                 if x=fail or y=fail then return fail; fi;
                 x := MappedWord(x,Fgens,Sgens)/Fgens[1]*
                      MappedWord(y,Fgens,Sgens);
-                if ISONE@(i[2]) then x := x*Fgens[1]; fi;
+                if Fr.ISONE(i[2]) then x := x*Fgens[1]; fi;
                 if MappedWord(x,Fgens,Ggens)<>g then return fail; fi;
                 AddDictionary(knows,g,x);
                 return x;
@@ -1714,7 +1714,7 @@ BindGlobal("PERIODICBKG_PREIMAGE@", function(G,depth)
     return rec(F:=F, image:=image, preimage:=preimage, reduce:=w->w);
 end);
 
-BindGlobal("PREPERIODICBKG_PREIMAGE@", function(G,depth)
+Fr.PREPERIODICBKG_PREIMAGE := ( function(G,depth)
     local kseq, k, n, d, a, b, i, j, rel, sigma, t, w,
           glob_t, glob_s, glob_m, glob_u,
           makeSgens, image, knows, preimage, dihedralimage, reduce, tau,
@@ -1869,7 +1869,7 @@ BindGlobal("PREPERIODICBKG_PREIMAGE@", function(G,depth)
             creator := ElementOfFpGroup;
         fi;
         if glob_m<infinity then
-            Append(rel,ITERATEMAP@(sigma,depth,(Fgens[1]*glob_t)^(2^(glob_m+1))));
+            Append(rel,Fr.ITERATEMAP(sigma,depth,(Fgens[1]*glob_t)^(2^(glob_m+1))));
             for i in [1..2^glob_m] do
                 Add(O[2-RemInt(i,2)], (glob_t*Fgens[1])^i);
                 Add(O[1+RemInt(i,2)], (Fgens[1]*glob_t)^(i+1));
@@ -1880,9 +1880,9 @@ BindGlobal("PREPERIODICBKG_PREIMAGE@", function(G,depth)
         for i in Concatenation([2..k],[k+2..k+n]) do
             for j in Concatenation([2..k],[k+2..k+n]) do
                 if kseq[i-1]=kseq[j-1] then
-                    for w in O[1] do Append(rel,ITERATEMAP@(sigma,depth,Comm(Fgens[i],Fgens[j]^w))); od;
+                    for w in O[1] do Append(rel,Fr.ITERATEMAP(sigma,depth,Comm(Fgens[i],Fgens[j]^w))); od;
                 else
-                    for w in O[2] do Append(rel,ITERATEMAP@(sigma,depth,Comm(Fgens[i],Fgens[j]^w))); od;
+                    for w in O[2] do Append(rel,Fr.ITERATEMAP(sigma,depth,Comm(Fgens[i],Fgens[j]^w))); od;
                 fi;
             od;
         od;
@@ -1992,7 +1992,7 @@ BindGlobal("PREPERIODICBKG_PREIMAGE@", function(G,depth)
                     y := recur(i[1][2]);
                     if x=fail or y=fail then return fail; fi;
                     x := x^t*b/tau(i[1][1],rel[1],rel[2])^t*y^t;
-                    if ISONE@(i[2]) then x := x*b; fi;
+                    if Fr.ISONE(i[2]) then x := x*b; fi;
                     if MappedWord(x,Fgens,Ggens)<>g then return fail; fi;
                     AddDictionary(knows,g,x);
                     return x;
@@ -2078,7 +2078,7 @@ BindGlobal("PREPERIODICBKG_PREIMAGE@", function(G,depth)
                     x := MappedWord(x,Fgens,Sgens)*Fgens[1]/
                          MappedWord(tau(i[1][1],glob_s,Fgens[k]),Fgens,Sgens)*
                          MappedWord(y,Fgens,Sgens);
-                    if ISONE@(i[2]) then x := x*Fgens[1]; fi;
+                    if Fr.ISONE(i[2]) then x := x*Fgens[1]; fi;
                     if MappedWord(x,Fgens,Ggens)<>g then return fail; fi;
                     AddDictionary(knows,g,x);
                     return x;
@@ -2093,19 +2093,19 @@ end);
 
 InstallGlobalFunction(BinaryKneadingMachine, function(arg)
     local t;
-    t := CallFuncList(BINARYKNEADINGMACHINE@,arg);
+    t := CallFuncList(Fr.BINARYKNEADINGMACHINE,arg);
     SetName(t[1],Concatenation("BinaryKneadingMachine",t[3]));
     return t[1];
 end);
 
 InstallGlobalFunction(BinaryKneadingGroup, function(arg)
     local t;
-    t := CallFuncList(BINARYKNEADINGMACHINE@,arg);
+    t := CallFuncList(Fr.BINARYKNEADINGMACHINE,arg);
     SetName(t[2],Concatenation("BinaryKneadingGroup",t[3]));
     if PrePeriod(KneadingSequence(t[2]))="" then
-        SetFRGroupPreImageData(t[2],n->PERIODICBKG_PREIMAGE@(t[2],n));
+        SetFRGroupPreImageData(t[2],n->Fr.PERIODICBKG_PREIMAGE(t[2],n));
     else
-        SetFRGroupPreImageData(t[2],n->PREPERIODICBKG_PREIMAGE@(t[2],n));
+        SetFRGroupPreImageData(t[2],n->Fr.PREPERIODICBKG_PREIMAGE(t[2],n));
     fi;
     SetIsBoundedFRSemigroup(t[2],true);
     NucleusOfFRSemigroup(t[2]);
@@ -2114,7 +2114,7 @@ end);
 
 BindGlobal("BasilicaGroup", BinaryKneadingGroup("1"));
 BasilicaGroup!.Name := "BasilicaGroup";
-SETGENERATORNAMES@(BasilicaGroup,["a","b"]);
+Fr.SETGENERATORNAMES(BasilicaGroup,["a","b"]);
 SetName(GeneratorsOfSemigroup(BasilicaGroup)[4],"a^-1");
 SetName(GeneratorsOfSemigroup(BasilicaGroup)[5],"b^-1");
 SetName(NucleusOfFRSemigroup(BasilicaGroup)[4],"a"); #???
@@ -2135,13 +2135,13 @@ BindGlobal("I2Machine",MealyMachine([[1,1],[2,1]],[(1,2),[2,2]]));
 
 BindGlobal("I2Monoid",SCMonoid(I2Machine));
 SetName(I2Monoid,"I2");
-SETGENERATORNAMES@(I2Monoid,["f0","f1"]);
+Fr.SETGENERATORNAMES(I2Monoid,["f0","f1"]);
 
 BindGlobal("I4Machine",MealyMachine([[3,3],[1,2],[3,3]],[(1,2),[1,1],()]));
 
 BindGlobal("I4Monoid",SCMonoid(I4Machine));
 SetName(I4Monoid,"I4");
-SETGENERATORNAMES@(I4Monoid,["s","f"]);
+Fr.SETGENERATORNAMES(I4Monoid,["s","f"]);
 #############################################################################
 
 #############################################################################
@@ -2149,7 +2149,7 @@ SETGENERATORNAMES@(I4Monoid,["s","f"]);
 #
 InstallGlobalFunction(PSZAlgebra, function(arg)
     local p, t, u, i, k, m;
-    
+
     while Length(arg)=0 or Length(arg)>2 do
         Error("PSZAlgebra: need 1 or 2 arguments");
     od;
@@ -2172,25 +2172,25 @@ InstallGlobalFunction(PSZAlgebra, function(arg)
     else
         m := 2;
     fi;
-    
+
     u := NullMat(m+1,m+1,k);
-    t := MATRIX@(IdentityMat(p,k),i->u);
-    
+    t := Fr.MATRIX(IdentityMat(p,k),i->u);
+
     u := NullMat(m+1,m+1,k);
     for i in [1..m-1] do
         u[i+1][i] := One(k);
     od;
     u[m+1][m+1] := One(k);
     for i in [1..p] do t[i][i] := u; od;
-    
+
     u := NullMat(m+1,m+1,k);
     u[1][m+1] := One(k);
     for i in [1..p-1] do t[i+1][i] := u; od;
-    
+
     u := NullMat(m+1,m+1,k);
     u[m][m] := -One(k);
     t[1][p] := u;
-    
+
     u := ListWithIdenticalEntries(m+1,Zero(k)); u[m+1] := One(k);
     t := SCAlgebraWithOne(VectorMachine(k,t,u));
     SetName(t,Concatenation("PSZAlgebra(",String(k),",",String(m),")"));
@@ -2202,7 +2202,7 @@ InstallGlobalFunction(PSZAlgebra, function(arg)
         od;
     fi;
     SetName(t.2,"v");
-    
+
     for i in [1..m] do
         SetDegreeOfHomogeneousElement(t.(i),IdentityMat(m)[i]);
     od;
@@ -2213,7 +2213,7 @@ InstallGlobalFunction(PSZAlgebra, function(arg)
     AddDictionary(t!.components,Zero(Integers^m),i);
     SetGrading(t,rec(source := Integers^m, hom_components := function(arg)
         local i, j, v;
-        
+
         while not arg in Grading(t).source do
             Error("Grading degree ",arg," must belong to ",Grading(t).source);
         od;
@@ -2281,7 +2281,7 @@ InstallGlobalFunction(GuptaSidkiThinnedAlgebra, function(k)
 
     if IsPosInt(k) then k := GF(k); fi;
 
-    a := THINNEDALGEBRAWITHONE@(k,GuptaSidkiGroup,GeneratorsOfGroup(GuptaSidkiGroup));
+    a := Fr.THINNEDALGEBRAWITHONE(k,GuptaSidkiGroup,GeneratorsOfGroup(GuptaSidkiGroup));
     return a;
 end);
 

--- a/gap/frelement.gi
+++ b/gap/frelement.gi
@@ -28,7 +28,7 @@ InstallMethod(SetUnderlyingMealyElement, "(FR) for two FR elements",
         function(E,M)
     E![3] := M;
     SetFilterObj(E,HasUnderlyingMealyElement);
-end);    
+end);
 
 InstallMethod(UnderlyingMealyElement, "(FR) for an FR element",
         [IsFRElement and IsFRElementStdRep],
@@ -106,7 +106,7 @@ InstallMethod(FREFamily, "(FR) for a FR element",
 #O FRElement(Group, Transitions, Output, Init)
 #O FRElement(FRMachine, Init)
 ##
-BindGlobal("FRETYPE@", function(f)
+Fr.FRETYPE := ( function(f)
     if IsGroup(f) then
         return IsGroupFRElement and IsFRElementStdRep;
     elif HasIsFreeMonoid(f) and IsFreeMonoid(f) then
@@ -121,14 +121,14 @@ end);
 InstallOtherMethod(FRElementNC, "(FR) for a family, a free semigroup, a list of transitions, a list of outputs and an initial state",
         [IsFamily, IsSemigroup, IsList, IsList, IsAssocWord],
         function(fam,free,transitions,output,init)
-    return Objectify(NewType(fam, FRETYPE@(free)),
+    return Objectify(NewType(fam, Fr.FRETYPE(free)),
                    [FRMachineNC(FRMFamily(fam),free,transitions,output),Immutable(init)]);
 end);
 
 InstallMethod(FRElementNC, "(FR) for a FR machine and an initial word",
         [IsFamily, IsFRMachine and IsFRMachineStdRep, IsAssocWord],
         function(fam,M,init)
-    return Objectify(NewType(fam, FRETYPE@(M!.free)),
+    return Objectify(NewType(fam, Fr.FRETYPE(M!.free)),
                    [M,Immutable(init)]);
 end);
 
@@ -295,39 +295,39 @@ InstallMethod(ViewString, "(FR) for a FR element",
         function(E)
     local s;
     s := "";
-    APPEND@(s,"<", Size(AlphabetOfFRObject(E)), "|");
+    Fr.APPEND(s,"<", Size(AlphabetOfFRObject(E)), "|");
     if HasOne(UnderlyingFRMachine(E)!.free) and IsOne(InitialState(E)) then
-        APPEND@(s,"identity ...");
+        Fr.APPEND(s,"identity ...");
     else
-        APPEND@(s,InitialState(E));
+        Fr.APPEND(s,InitialState(E));
     fi;
     if HasUnderlyingMealyElement(E) then
-        APPEND@(s,"|",Length(StateSet(UnderlyingMealyElement(E))));
+        Fr.APPEND(s,"|",Length(StateSet(UnderlyingMealyElement(E))));
     fi;
-    APPEND@(s,">");
+    Fr.APPEND(s,">");
     return s;
 end);
 
 InstallMethod(String, "(FR) for a FR element",
         [IsFRElement and IsFRElementStdRep],
         function(E)
-    return CONCAT@("FRElement(...,",InitialState(E),")");
+    return Fr.CONCAT("FRElement(...,",InitialState(E),")");
 end);
 
 InstallMethod(DisplayString, "(FR) for a FR element",
         [IsFRElement and IsFRElementStdRep],
         function(E)
-    return CONCAT@(DisplayString(UnderlyingFRMachine(E)),"Initial state: ",InitialState(E),"\n");
+    return Fr.CONCAT(DisplayString(UnderlyingFRMachine(E)),"Initial state: ",InitialState(E),"\n");
 end);
 
-INSTALLPRINTERS@(IsFRElement);
+Fr.INSTALLPRINTERS(IsFRElement);
 #############################################################################
 
 #############################################################################
 ##
 #M One(FRElement)
 ##
-BindGlobal("ONE@", function(E)
+Fr.ONE := ( function(E)
     local e;
     e := FRElement(E![1],One(E![2]));
     if HasUnderlyingMealyElement(E) then
@@ -335,14 +335,14 @@ BindGlobal("ONE@", function(E)
     fi;
     return e;
 end);
-    
+
 InstallMethod(OneOp, "(FR) for a FR element",
         [IsGroupFRElement],
-        ONE@);
+        Fr.ONE);
 
 InstallMethod(OneOp, "(FR) for a FR element",
         [IsMonoidFRElement],
-        ONE@);
+        Fr.ONE);
 
 InstallMethod(OneOp, "(FR) for a FR element",
         [IsSemigroupFRElement],
@@ -361,7 +361,7 @@ end);
 ##
 #M InverseOp(FRElement)
 ##
-BindGlobal("INVOLVEDGENERATORS@", function(E)
+Fr.INVOLVEDGENERATORS := ( function(E)
     local s, olds;
     s := Set(List(LetterRepAssocWord(E![2]),AbsInt));
     repeat
@@ -371,7 +371,7 @@ BindGlobal("INVOLVEDGENERATORS@", function(E)
     return s;
 end);
 
-BindGlobal("REVERSEDWORD@", function(w)
+Fr.REVERSEDWORD := ( function(w)
     return AssocWordByLetterRep(FamilyObj(w),Reversed(LetterRepAssocWord(w)));
 end);
 
@@ -383,23 +383,23 @@ InstallMethod(InverseOp, "(FR) for a group FR element",
         rws := NewFRMachineRWS(E![1]);
         e := FRElement(E![1], rws.letterunrep(rws.reduce(rws.letterrep(E![2]^-1))));
     else
-        s := INVOLVEDGENERATORS@(E);
+        s := Fr.INVOLVEDGENERATORS(E);
         trans := [];
         out := [];
         for i in [1..Length(E![1]!.transitions)] do
             if i in s then
-                if ISINVERTIBLE@(E![1]!.output[i]) then
-                    Add(out,INVERSE@(E![1]!.output[i]));
+                if Fr.ISINVERTIBLE(E![1]!.output[i]) then
+                    Add(out,Fr.INVERSE(E![1]!.output[i]));
                 else
                     return fail;
                 fi;
-                Add(trans,List(E![1]!.transitions[i]{out[Length(out)]},REVERSEDWORD@));
+                Add(trans,List(E![1]!.transitions[i]{out[Length(out)]},Fr.REVERSEDWORD));
             else
                 Add(trans,E![1]!.transitions[i]);
                 Add(out,E![1]!.output[i]);
             fi;
         od;
-        e := FRElementNC(FamilyObj(E),E![1]!.free,trans,out,REVERSEDWORD@(E![2]));
+        e := FRElementNC(FamilyObj(E),E![1]!.free,trans,out,Fr.REVERSEDWORD(E![2]));
     fi;
     if HasUnderlyingMealyElement(E) then
         SetUnderlyingMealyElement(e,InverseOp(UnderlyingMealyElement(E)));
@@ -411,7 +411,7 @@ InstallMethod(IsInvertible, "(FR) for an FR element",
         [IsFRElement and IsFRElementStdRep],
         function(E)
     return (HasIsGroupFRMachine(E![1]) and IsGroupFRMachine(E![1])) or
-           ForAll(INVOLVEDGENERATORS@(E),s->ISINVERTIBLE@(E![1]!.output[s]));
+           ForAll(Fr.INVOLVEDGENERATORS(E),s->Fr.ISINVERTIBLE(E![1]!.output[s]));
 end);
 #############################################################################
 
@@ -427,7 +427,7 @@ InstallMethod(\*, "(FR) for two FR elements",
     if IsIdenticalObj(left![1],right![1]) then
         rws := NewFRMachineRWS(left![1]);
         e := FRElement(left![1], rws.letterunrep(rws.reduce(rws.letterrep(left![2]*right![2]))));
-    else    
+    else
         N := SubFRMachine(left![1],right![1]);
         if N <> fail then
             return FRElement(left![1],left![2]*right![2]^N);
@@ -522,7 +522,7 @@ InstallOtherMethod(State, "(FR) for an FR element and a list",
     if HasUnderlyingMealyElement(E) then
         SetUnderlyingMealyElement(e,State(UnderlyingMealyElement(E),x));
     fi;
-    return e;    
+    return e;
 end);
 #############################################################################
 
@@ -576,7 +576,7 @@ InstallMethod(Transitions, "(FR) for an FR element and a state",
     return Transitions(E![1],s);
 end);
 
-BindGlobal("MAKEPERMS@", function(M,l)
+Fr.MAKEPERMS := ( function(M,l)
     local d, i, j, k, s, p, q, perms, oldperms, S, SR;
     d := Size(AlphabetOfFRObject(M));
     S := GeneratorsOfFRMachine(M);
@@ -593,7 +593,7 @@ BindGlobal("MAKEPERMS@", function(M,l)
                     if k>0 then
                         q := oldperms[k]{q};
                     else
-                        q := INVERSE@(oldperms[-k]){q};
+                        q := Fr.INVERSE(oldperms[-k]){q};
                     fi;
                 od;
                 Append(p,q+d^(i-1)*(s[2][j]-1));
@@ -604,7 +604,7 @@ BindGlobal("MAKEPERMS@", function(M,l)
     return perms;
 end);
 
-BindGlobal("PERMORTRANSFORMATION@", function(t)
+Fr.PERMORTRANSFORMATION := ( function(t)
     if RankOfTransformation(t)=DegreeOfTransformation(t) then
         return AsPermutation(t);
     fi;
@@ -613,7 +613,7 @@ end);
 
 InstallMethod(Activity, "(FR) for an FR element",
         [IsFRElement],
-        E->PERMORTRANSFORMATION@(TransformationList(Output(E))));
+        E->Fr.PERMORTRANSFORMATION(TransformationList(Output(E))));
 
 InstallMethod(ActivityTransformation, "(FR) for an FR element",
         [IsFRElement],
@@ -639,28 +639,28 @@ end);
 InstallMethod(Activity, "(FR) for a group FR element and a level",
         [IsGroupFRElement and IsFRElementStdRep, IsInt],
         function(E,l)
-    return MAPPEDWORD@(E![2],List(MAKEPERMS@(E![1],l),PermList),());
+    return Fr.MAPPEDWORD(E![2],List(Fr.MAKEPERMS(E![1],l),PermList),());
 end);
 
 InstallMethod(Activity, "(FR) for an FR element and a level",
         [IsFRElement and IsFRElementStdRep, IsInt],
         function(E,l)
-    return PERMORTRANSFORMATION@(ActivityTransformation(E,l));
+    return Fr.PERMORTRANSFORMATION(ActivityTransformation(E,l));
 end);
 
 InstallMethod(ActivityTransformation, "(FR) for an FR element and a level",
         [IsFRElement and IsFRElementStdRep, IsInt],
         function(E,l)
-    return MAPPEDWORD@(E![2],List(MAKEPERMS@(E![1],l),Transformation),IdentityTransformation);
+    return Fr.MAPPEDWORD(E![2],List(Fr.MAKEPERMS(E![1],l),Transformation),IdentityTransformation);
 end);
 
 InstallMethod(ActivityPerm, "(FR) for an FR element and a level",
         [IsFRElement and IsFRElementStdRep, IsInt],
         function(E,l)
-    return MAPPEDWORD@(E![2],List(MAKEPERMS@(E![1],l),PermList),());
+    return Fr.MAPPEDWORD(E![2],List(Fr.MAKEPERMS(E![1],l),PermList),());
 end);
 
-BindGlobal("INT2SEQ@", function(x,l,n)
+Fr.INT2SEQ := ( function(x,l,n)
     local s, i;
     s := [];
     x := x-1;
@@ -671,7 +671,7 @@ BindGlobal("INT2SEQ@", function(x,l,n)
     return s;
 end);
 
-BindGlobal("SEQ2INT@", function(s,l,n)
+Fr.SEQ2INT := ( function(s,l,n)
     return 1+Sum([1..l],i->(s[i]-1)*n^(i-1));
 end);
 
@@ -680,9 +680,9 @@ InstallMethod(ActivityInt, "(FR) for an FR machine and a state",
         function(E,l)
     local p, n, i, delta, x;
     n := Size(AlphabetOfFRObject(E));
-    p := ANY2OUT@(Activity(E,l),n^l);
+    p := Fr.ANY2OUT(Activity(E,l),n^l);
     if p=fail then return fail; fi;
-    x := List([1..n^l],i->SEQ2INT@(Reversed(INT2SEQ@(i,l,n)),l,n));
+    x := List([1..n^l],i->Fr.SEQ2INT(Reversed(Fr.INT2SEQ(i,l,n)),l,n));
     delta := Position(x,p[1])-1;
     if p{x}=Concatenation(x{[1+delta..n^l]},x{[1..delta]}) then
         return delta;
@@ -691,38 +691,37 @@ InstallMethod(ActivityInt, "(FR) for an FR machine and a state",
     fi;
 end);
 
-PORTRAIT@ := fail; # shut up warning
-PORTRAIT@ := function(g,n,act)
+Fr.PORTRAIT := fail; # shut up warning
+Fr.PORTRAIT := function(g,n,act)
     if n=0 then
         return act(g,1);
     else
-        return List(AlphabetOfFRObject(g),a->PORTRAIT@(State(g,a),n-1,act));
+        return List(AlphabetOfFRObject(g),a->Fr.PORTRAIT(State(g,a),n-1,act));
     fi;
 end;
-MakeReadOnlyGlobal("PORTRAIT@");
 
 InstallMethod(Portrait, "(FR) for an FR element an a maximal level",
         [IsFRElement, IsInt],
         function(E,l)
-    return List([0..l],i->PORTRAIT@(E,i,Activity));
+    return List([0..l],i->Fr.PORTRAIT(E,i,Activity));
 end);
 
 InstallMethod(PortraitPerm, "(FR) for an FR element an a maximal level",
         [IsFRElement, IsInt],
         function(E,l)
-    return List([0..l],i->PORTRAIT@(E,i,ActivityPerm));
+    return List([0..l],i->Fr.PORTRAIT(E,i,ActivityPerm));
 end);
 
 InstallMethod(PortraitTransformation, "(FR) for an FR element an a maximal level",
         [IsFRElement, IsInt],
         function(E,l)
-    return List([0..l],i->PORTRAIT@(E,i,ActivityTransformation));
+    return List([0..l],i->Fr.PORTRAIT(E,i,ActivityTransformation));
 end);
 
 InstallMethod(PortraitInt, "(FR) for an FR element an a maximal level",
         [IsFRElement, IsInt],
         function(E,l)
-    return List([0..l],i->PORTRAIT@(E,i,ActivityInt));
+    return List([0..l],i->Fr.PORTRAIT(E,i,ActivityInt));
 end);
 
 InstallMethod(DecompositionOfFRElement, "(FR) for an FR element",
@@ -764,7 +763,7 @@ end);
 ##
 #M \=(FRElement, FRElement)
 ##
-BindGlobal("GROUPISONE@", function(m,w)
+Fr.GROUPISONE := ( function(m,w)
     local rws, todo, d, t, u;
 
     rws := NewFRMachineRWS(m);
@@ -773,7 +772,7 @@ BindGlobal("GROUPISONE@", function(m,w)
         u := rws.reduce(rws.cyclicallyreduce(t));
         if u<>[] then
             d := rws.pi(u);
-            if not ISONE@(d[2]) then return false; fi;
+            if not Fr.ISONE(d[2]) then return false; fi;
             rws.addgprule(u,true);
             Append(todo,d[1]);
         fi;
@@ -782,14 +781,14 @@ BindGlobal("GROUPISONE@", function(m,w)
     return true;
 end);
 
-BindGlobal("MONOIDCOMPARE@", function(m,v,w)
+Fr.MONOIDCOMPARE := ( function(m,v,w)
     # returns 0 if v=w in machine m,
     # returns -1 if v<w, and returns 1 if v>w
     local rws, todo, d, t;
 
     rws := NewFRMachineRWS(m);
     todo := NewFIFO([[rws.letterrep(v),rws.letterrep(w)]]);
-    
+
     for t in todo do
         t := List(t,rws.reduce);
         if t[1]<>t[2] then
@@ -817,17 +816,17 @@ InstallMethod(\=, "(FR) for two group FR elements",
         [IsGroupFRElement and IsFRElementStdRep, IsGroupFRElement and IsFRElementStdRep],
         function(left, right)
     local m;
-    
+
     if IsIdenticalObj(left![1], right![1]) then
         if left![2]=right![2] then
             return true;
         else
-            return GROUPISONE@(left![1],left![2]/right![2]);
+            return Fr.GROUPISONE(left![1],left![2]/right![2]);
         fi;
     fi;
-    m := FRMMINSUM@(left![1],right![1]);
+    m := Fr.FRMMINSUM(left![1],right![1]);
     left := left![2]^Correspondence(m)[1]/right![2]^Correspondence(m)[2];
-    return GROUPISONE@(m,left);
+    return Fr.GROUPISONE(m,left);
 end);
 
 InstallMethod(\=, "(FR) for two FR elements",
@@ -835,16 +834,16 @@ InstallMethod(\=, "(FR) for two FR elements",
         [IsFRElement and IsFRElementStdRep, IsFRElement and IsFRElementStdRep],
         function(left, right)
     local m;
-    
+
     if IsIdenticalObj(left![1], right![1]) then
         if left![2]=right![2] then
             return true;
         else
-            return MONOIDCOMPARE@(left![1],left![2],right![2])=0;
+            return Fr.MONOIDCOMPARE(left![1],left![2],right![2])=0;
         fi;
     fi;
-    m := FRMMINSUM@(left![1],right![1]);
-    return MONOIDCOMPARE@(m,left![2]^Correspondence(m)[1],right![2]^Correspondence(m)[2])=0;
+    m := Fr.FRMMINSUM(left![1],right![1]);
+    return Fr.MONOIDCOMPARE(m,left![2]^Correspondence(m)[1],right![2]^Correspondence(m)[2])=0;
 end);
 
 InstallMethod(IsOne, "(FR) for a group FR element",
@@ -859,7 +858,7 @@ InstallMethod(IsOne, "(FR) for a group FR element",
     if IsOne(E![2]) then
         return true;
     fi;
-    return GROUPISONE@(E![1],E![2]);
+    return Fr.GROUPISONE(E![1],E![2]);
 end);
 
 InstallMethod(IsOne, "(FR) for a FR element",
@@ -868,7 +867,7 @@ InstallMethod(IsOne, "(FR) for a FR element",
     if HasOne(E![1]!.free) and IsOne(E![2]) then
         return true;
     else
-        return MONOIDCOMPARE@(E![1],E![2],
+        return Fr.MONOIDCOMPARE(E![1],E![2],
                        AssocWordByLetterRep(FamilyObj(E![2]),[]))=0;
     fi;
 end);
@@ -899,10 +898,10 @@ InstallMethod(\<, "(FR) for two FR elements",
         function(left, right)
     local m;
     if IsIdenticalObj(left![1],right![1]) then
-        return MONOIDCOMPARE@(left![1],left![2],right![2])<0;
+        return Fr.MONOIDCOMPARE(left![1],left![2],right![2])<0;
     else
-        m := FRMMINSUM@(left![1],right![1]);
-        return MONOIDCOMPARE@(m,left![2]^Correspondence(m)[1],right![2]^Correspondence(m)[2])<0;
+        m := Fr.FRMMINSUM(left![1],right![1]);
+        return Fr.MONOIDCOMPARE(m,left![2]^Correspondence(m)[1],right![2]^Correspondence(m)[2])<0;
     fi;
 end);
 #############################################################################
@@ -1020,7 +1019,7 @@ InstallMethod(States, "(FR) for a list of FR elements",
     return states;
 end);
 
-BindGlobal("FRFIXEDSTATES@", function(L)
+Fr.FRFIXEDSTATES := ( function(L)
     local states, i, x, addstates, stateset;
     states := [];
     stateset := [];
@@ -1047,14 +1046,14 @@ end);
 
 InstallMethod(FixedStatesOfFRElement, "(FR) for an FR element",
         [IsFRElement],
-        E->FRFIXEDSTATES@([E]));
+        E->Fr.FRFIXEDSTATES([E]));
 InstallMethod(FixedStates, "(FR) for an FR element",
         [IsFRElement],
         FixedStatesOfFRElement);
 
 InstallMethod(FixedStates, "(FR) for a list of FR elements",
         [IsFRElementCollection],
-        FRFIXEDSTATES@);
+        Fr.FRFIXEDSTATES);
 
 InstallMethod(IsFiniteStateFRMachine, "(FR) for an FR machine",
         [IsFRMachine],
@@ -1064,7 +1063,7 @@ InstallMethod(IsFiniteStateFRElement, "(FR) for an FR element",
         [IsFRElement],
         e->CategoryCollections(IsFRElement)(States(e)));
 
-BindGlobal("FRLIMITSTATES@", function(L)
+Fr.FRLIMITSTATES := ( function(L)
     local s, d, S, oldS;
     s := Set(States(L));
     d := List(s,w->BlistList([1..Length(s)],List(DecompositionOfFRElement(w)[1],x->Position(s,x))));
@@ -1078,16 +1077,16 @@ end);
 
 InstallMethod(LimitStatesOfFRElement, "(FR) for an FR element",
         [IsFRElement],
-        E->FRLIMITSTATES@([E]));
+        E->Fr.FRLIMITSTATES([E]));
 InstallMethod(LimitStates, "(FR) for an FR element",
         [IsFRElement],
         LimitStatesOfFRElement);
 
 InstallMethod(LimitStates, "(FR) for a list of FR elements",
         [IsFRElementCollection],
-        FRLIMITSTATES@);
+        Fr.FRLIMITSTATES);
 
-BindGlobal("MAYBE_ORDER@", function(e,limit)
+Fr.MAYBE_ORDER := ( function(e,limit)
     # does the element e have provable infinite order, within raising to power
     # 'limit'?
     local testing, found, recur;
@@ -1129,7 +1128,7 @@ BindGlobal("MAYBE_ORDER@", function(e,limit)
     return recur(e,1);
 end);
 
-BindGlobal("NUCLEUS@", function(L)
+Fr.NUCLEUS := ( function(L)
     local s, news, olds, gens, i, j, maybeinf;
 
     gens := Set(L);
@@ -1145,7 +1144,7 @@ BindGlobal("NUCLEUS@", function(L)
         fi;
 
         i := 1; while i <= Size(maybeinf) do
-            j := MAYBE_ORDER@(maybeinf[i],Size(s));
+            j := Fr.MAYBE_ORDER(maybeinf[i],Size(s));
             if j=infinity then
                 return fail;
             elif j=fail then
@@ -1168,7 +1167,7 @@ end);
 
 InstallMethod(NucleusOfFRMachine, "(FR) for an FR machine",
         [IsFRMachine],
-        M->NUCLEUS@(List(GeneratorsOfFRMachine(M),x->FRElement(M,x))));
+        M->Fr.NUCLEUS(List(GeneratorsOfFRMachine(M),x->FRElement(M,x))));
 #############################################################################
 
 #############################################################################
@@ -1178,9 +1177,9 @@ InstallMethod(NucleusOfFRMachine, "(FR) for an FR machine",
 ## is proved to terminate for bounded elements, by Said Sidki (personal
 ## communication); otherwise could run forever
 ##
-BindGlobal("ORDER@", function(e)
+Fr.ORDER := ( function(e)
     local testing, found, recur;
-    
+
     if HasUnderlyingMealyElement(e) then
         e := UnderlyingMealyElement(e);
     fi;
@@ -1188,7 +1187,7 @@ BindGlobal("ORDER@", function(e)
     if not IsInvertible(e) then
 	return fail;
     fi;
-    
+
     if IsAbelian(VertexTransformationsFRElement(e)) then
         found := NewDictionary(e,false);
         recur := function(e)
@@ -1210,7 +1209,7 @@ BindGlobal("ORDER@", function(e)
             return infinity;
         fi;
     fi;
-    
+
     testing := NewDictionary(e,true); # current order during recursion
     found := NewDictionary(e,true); # elements for which we found the order
     AddDictionary(testing,One(e),infinity);
@@ -1250,11 +1249,11 @@ BindGlobal("ORDER@", function(e)
 end);
 
 InstallMethod(Order, "(FR) for an FR element; not guaranteed to terminate",
-        [IsFRElement and IsFRElementStdRep], ORDER@);
-        
+        [IsFRElement and IsFRElementStdRep], Fr.ORDER);
+
 InstallMethod(Order, "(FR) for a Mealy element; not guaranteed to terminate",
-        [IsMealyElement], ORDER@);
-        
+        [IsMealyElement], Fr.ORDER);
+
 InstallMethod(IsLevelTransitiveFRElement, "(FR) for a group FR element",
         [IsGroupFRMealyElement],
         E->IsLevelTransitiveFRElement(UnderlyingMealyElement(E)));

--- a/gap/frmachine.gi
+++ b/gap/frmachine.gi
@@ -25,7 +25,7 @@ InstallMethod(AlphabetOfFRObject, "(FR) for an FR object",
     return a;
 end);
 
-INSTALLPRINTERS@(IsFRObject);
+Fr.INSTALLPRINTERS(IsFRObject);
 
 InstallMethod(FRMFamily, "(FR) for an alphabet",
         [IsListOrCollection],
@@ -101,7 +101,7 @@ InstallOtherMethod(FRMachineNC, "(FR) for a family, a free monoid, a list of tra
     return M;
 end);
 
-BindGlobal("COPYFRMACHINE@", function(m)
+Fr.COPYFRMACHINE := ( function(m)
     return Objectify(NewType(FamilyObj(m), First([IsGroupFRMachine,IsMonoidFRMachine,IsSemigroupFRMachine],p->Tester(p)(m) and p(m)) and IsFRMachineStdRep),
                    rec(free := m!.free,
                        pack := m!.pack,
@@ -109,7 +109,7 @@ BindGlobal("COPYFRMACHINE@", function(m)
                        output := m!.output));
 end);
 
-BindGlobal("ANY2OUT@", function(x,n)
+Fr.ANY2OUT := ( function(x,n)
     if IsList(x) then
         return x;
     elif IsTransformation(x) then
@@ -119,7 +119,7 @@ BindGlobal("ANY2OUT@", function(x,n)
     fi;
 end);
 
-BindGlobal("CHECKLENGTHSCONTENTS@", function(t, transitions, output)
+Fr.CHECKLENGTHSCONTENTS := ( function(t, transitions, output)
     # check validity of arguments;
     # unpack FR elements contained in the transitions;
     # set t.F
@@ -168,7 +168,7 @@ BindGlobal("CHECKLENGTHSCONTENTS@", function(t, transitions, output)
     # clean up t.output, set t.invertible
     t.invertible := true;
     for i in [1..Length(t.output)] do
-        t.output[i] := ANY2OUT@(t.output[i],Length(t.F!.alphabet));
+        t.output[i] := Fr.ANY2OUT(t.output[i],Length(t.F!.alphabet));
         if Set(t.output[i])<>t.F!.alphabet then
             t.invertible := false;
         fi;
@@ -186,7 +186,7 @@ InstallMethod(FRMachine, "(FR) for a list of transitions and a list of outputs",
         function(transitions, output)
     local G, elG, t;
     t := rec();
-    CHECKLENGTHSCONTENTS@(t, transitions, output);
+    Fr.CHECKLENGTHSCONTENTS(t, transitions, output);
     if t.invertible then
         G := FreeGroup(Length(t.transitions));
     else
@@ -204,7 +204,7 @@ InstallMethod(FRMachine, "(FR) for a list of names, a list of transitions and a 
     if not ForAll(names,IsString) then
         Error("<names> should be a list of strings, and not ", names,"\n");
     fi;
-    CHECKLENGTHSCONTENTS@(t, transitions, output);
+    Fr.CHECKLENGTHSCONTENTS(t, transitions, output);
     if Length(names)>Length(t.transitions) then
         Error("Too many names supplied to FRMachine()\n");
     elif Length(names)<Length(t.transitions) then
@@ -226,7 +226,7 @@ InstallMethod(FRMachine, "(FR) for a free [semi]group, a list of transitions and
         function(free,transitions,output)
     local t, elfree, r, i;
     t := rec();
-    CHECKLENGTHSCONTENTS@(t, transitions, output);
+    Fr.CHECKLENGTHSCONTENTS(t, transitions, output);
     if IsGroup(free) and not t.invertible then
         Error("Outputs must be invertible in group FR machine: ",t.output);
     fi;
@@ -271,16 +271,16 @@ InstallMethod(StateSet, "(FR) for an FR machine",
 InstallMethod(ViewString, "(FR) for an FR machine",
         [IsFRMachine and IsFRMachineStdRep],
         function(M)
-    return CONCAT@("<FR machine with alphabet ", AlphabetOfFRObject(M), " on ", StateSet(M), ">");
+    return Fr.CONCAT("<FR machine with alphabet ", AlphabetOfFRObject(M), " on ", StateSet(M), ">");
 end);
 
 InstallMethod(String, "(FR) for an FR machine",
         [IsFRMachine and IsFRMachineStdRep],
         function(M)
-    return CONCAT@("FRMachine(...,",M!.output,")");
+    return Fr.CONCAT("FRMachine(...,",M!.output,")");
 end);
 
-BindGlobal("DISPLAYFRMACHINE@", function(M)
+Fr.DISPLAYFRMACHINE := ( function(M)
     local a, i, j, g, alen, slen, glen, ablank, sblank, gblank, arule, grule, srule, StringId, s;
     a := AlphabetOfFRObject(M);
     g := GeneratorsOfFRMachine(M);
@@ -313,30 +313,30 @@ BindGlobal("DISPLAYFRMACHINE@", function(M)
     elif IsMonoidFRMachine(M) then
         s := " M";
     else s := " S"; fi;
-    APPEND@(s,gblank{[3..glen]}," |");
-    for i in [1..Length(a)] do APPEND@(s,sblank[i],String(a[i],-alen)," "); od;
-    APPEND@(s,"\n");
-    APPEND@(s,grule,"-+");
-    for i in [1..Length(a)] do APPEND@(s,srule[i],arule,"+"); od;
-    APPEND@(s,"\n");
+    Fr.APPEND(s,gblank{[3..glen]}," |");
+    for i in [1..Length(a)] do Fr.APPEND(s,sblank[i],String(a[i],-alen)," "); od;
+    Fr.APPEND(s,"\n");
+    Fr.APPEND(s,grule,"-+");
+    for i in [1..Length(a)] do Fr.APPEND(s,srule[i],arule,"+"); od;
+    Fr.APPEND(s,"\n");
     for i in [1..Length(g)] do
-        APPEND@(s,StringId(g[i],glen)," |");
+        Fr.APPEND(s,StringId(g[i],glen)," |");
         for j in [1..Length(a)] do
-            APPEND@(s,StringId(M!.transitions[i][j],slen[j]),",",String(M!.output[i][j],-alen));
+            Fr.APPEND(s,StringId(M!.transitions[i][j],slen[j]),",",String(M!.output[i][j],-alen));
         od;
-        APPEND@(s,"\n");
+        Fr.APPEND(s,"\n");
     od;
-    APPEND@(s,grule,"-+");
-    for i in [1..Length(a)] do APPEND@(s,srule[i],arule,"+"); od;
-    APPEND@(s,"\n");
+    Fr.APPEND(s,grule,"-+");
+    for i in [1..Length(a)] do Fr.APPEND(s,srule[i],arule,"+"); od;
+    Fr.APPEND(s,"\n");
     return s;
 end);
 
 InstallMethod(DisplayString, "(FR) for an FR machine",
         [IsFRMachine and IsFRMachineStdRep],
-        DISPLAYFRMACHINE@);
+        Fr.DISPLAYFRMACHINE);
 
-INSTALLPRINTERS@(IsFRMachine);
+Fr.INSTALLPRINTERS(IsFRMachine);
 #############################################################################
 ##
 #M One(FRMachine)
@@ -361,22 +361,22 @@ InstallOtherMethod(ZeroOp, "(FR) for an FR machine",
 ##
 InstallTrueMethod(IsInvertible, IsGroupFRMachine);
 
-BindGlobal("ISINVERTIBLE@", function(l)
+Fr.ISINVERTIBLE := ( function(l)
     return Set(l)=[1..Length(l)];
 end);
 
-BindGlobal("INVERSE@", function(l) # inverse of transformation, given as list
+Fr.INVERSE := ( function(l) # inverse of transformation, given as list
     local r;
     r := [];
     r{l} := [1..Length(l)];
     return r;
 end);
 
-BindGlobal("ISONE@", function(l) # identity mapping, given as list
+Fr.ISONE := ( function(l) # identity mapping, given as list
     return l=[1..Length(l)];
 end);
 
-BindGlobal("PREIMAGE@", Position); # preimage of point under transformation
+Fr.PREIMAGE := ( Position); # preimage of point under transformation
 
 InstallMethod(InverseOp, "(FR) for a group FR machine",
         [IsGroupFRMachine],
@@ -384,7 +384,7 @@ InstallMethod(InverseOp, "(FR) for a group FR machine",
     local N;
     N := FRMachineNC(FamilyObj(M), M!.free,
                  List([1..Length(M!.transitions)], i->M!.transitions[i]{M!.output[i]}),
-                 List(M!.output, INVERSE@));
+                 List(M!.output, Fr.INVERSE));
     SetInverse(M,N);
     SetInverse(N,M);
     return N;
@@ -408,7 +408,7 @@ end);
 ##
 #M Products
 ##
-BindGlobal("SET_NAME@", function(args,sep,obj)
+Fr.SET_NAME := ( function(args,sep,obj)
     local i, s, n;
     for i in args do if not HasName(i) then return; fi; od;
     s := ShallowCopy(Name(args[1]));
@@ -416,7 +416,7 @@ BindGlobal("SET_NAME@", function(args,sep,obj)
     SetName(obj,s);
 end);
 
-BindGlobal("MAKENAMESUNIQUE@", function(sgen)
+Fr.MAKENAMESUNIQUE := ( function(sgen)
     local i, j, nonunique;
     nonunique := Set(Filtered(Collected(Concatenation(sgen)),x->x[2]>1),x->x[1]);
     RemoveSet(nonunique,"<identity ...>");
@@ -429,7 +429,7 @@ BindGlobal("MAKENAMESUNIQUE@", function(sgen)
     od;
 end);
 
-BindGlobal("LARGESTDENOMINATOR@", function(arg)
+Fr.LARGESTDENOMINATOR := ( function(arg)
     # returns homomorphisms from all its arguments' free stateset to
     # a free object of highest structure (group > monoid > semigroup).
     # the last entry in the returned list is a list of appropriate generators
@@ -444,7 +444,7 @@ BindGlobal("LARGESTDENOMINATOR@", function(arg)
     sgen := List(gen,x->List(x,String));
 
     if ForAll(states,IsGroup) then
-        MAKENAMESUNIQUE@(sgen);
+        Fr.MAKENAMESUNIQUE(sgen);
         f := FreeGroup(Concatenation(sgen));
         c := [];
         shift := 0;
@@ -463,7 +463,7 @@ BindGlobal("LARGESTDENOMINATOR@", function(arg)
                 c[i] := c[i]*MappingByFunction(Range(c[i]),FreeMonoidOfFpMonoid(Range(c[i])),UnderlyingElement);
             fi;
         od;
-        MAKENAMESUNIQUE@(sgen);
+        Fr.MAKENAMESUNIQUE(sgen);
         f := FreeMonoid(Concatenation(sgen));
         shift := 0;
         for i in [1..d] do
@@ -487,7 +487,7 @@ BindGlobal("LARGESTDENOMINATOR@", function(arg)
                 c[i] := NaturalHomomorphismByGenerators(states[i],c[i])*iso*MappingByFunction(Range(iso),FreeSemigroupOfFpSemigroup(Range(iso)),UnderlyingElement);
             fi;
         od;
-        MAKENAMESUNIQUE@(sgen);
+        Fr.MAKENAMESUNIQUE(sgen);
         f := FreeSemigroup(Concatenation(sgen));
         shift := 0;
         for i in [1..d] do
@@ -500,10 +500,10 @@ BindGlobal("LARGESTDENOMINATOR@", function(arg)
     return c;
 end);
 
-BindGlobal("FRMSUM@", function(arg)
+Fr.FRMSUM := ( function(arg)
     local c, gen, trans, out, i, j, sum;
 
-    c := CallFuncList(LARGESTDENOMINATOR@,arg);
+    c := CallFuncList(Fr.LARGESTDENOMINATOR,arg);
     gen := Remove(c);
 
     trans := [];
@@ -516,13 +516,13 @@ BindGlobal("FRMSUM@", function(arg)
     od;
     sum := FRMachineNC(FamilyObj(arg[1]),Range(c[1]),trans,out);
     SetCorrespondence(sum,c);
-    SET_NAME@(arg,"+",sum);
+    Fr.SET_NAME(arg,"+",sum);
     return sum;
 end);
 
-BindGlobal("FRMMINSUM@", function(left,right)
+Fr.FRMMINSUM := ( function(left,right)
     local sum, r;
-    sum := FRMSUM@(left,right);
+    sum := Fr.FRMSUM(left,right);
     r := Minimized(sum);
     r!.Correspondence := List(Correspondence(sum),x->x*Correspondence(r));
     return r;
@@ -531,12 +531,12 @@ end);
 InstallMethod(\+, "(FR) for two FR machines",
         IsIdenticalObj,
         [IsFRMachine and IsFRMachineStdRep, IsFRMachine and IsFRMachineStdRep],
-        FRMSUM@);
+        Fr.FRMSUM);
 
 InstallMethod(\*, "(FR) for two FR machines",
         IsIdenticalObj,
         [IsFRMachine and IsFRMachineStdRep, IsFRMachine and IsFRMachineStdRep],
-        FRMSUM@);
+        Fr.FRMSUM);
 
 InstallMethod(TensorSumOp, "(FR) for two FR machines",
         [IsList, IsFRMachine and IsFRMachineStdRep],
@@ -564,7 +564,7 @@ InstallMethod(TensorSumOp, "(FR) for two FR machines",
         Add(out,o);
     od;
     x := FRMachineNC(FRMFamily([1..d]),N!.free,trans,out);
-    SET_NAME@(M,"(+)",x);
+    Fr.SET_NAME(M,"(+)",x);
     return x;
 end);
 
@@ -598,7 +598,7 @@ InstallMethod(TensorProductOp, "(FR) for two FR machines",
         Add(out,o);
     od;
     x := FRMachineNC(FRMFamily([1..Length(alphabet)]),N!.free,trans,out);
-    SET_NAME@(M,"(*)",x);
+    Fr.SET_NAME(M,"(*)",x);
     return x;
 end);
 
@@ -607,7 +607,7 @@ InstallMethod(DirectSumOp, "(FR) for two FR machines",
         function(M, N)
     local c, gen, trans, out, t, o, i, j, d, alph, shift, sum;
 
-    c := CallFuncList(LARGESTDENOMINATOR@,M);
+    c := CallFuncList(Fr.LARGESTDENOMINATOR,M);
     gen := Remove(c);
 
     d := 0;
@@ -632,7 +632,7 @@ InstallMethod(DirectSumOp, "(FR) for two FR machines",
     od;
     sum := FRMachineNC(FRMFamily([1..d]),Range(c[1]),trans,out);
     SetCorrespondence(sum,c);
-    SET_NAME@(M,"#",sum);
+    Fr.SET_NAME(M,"#",sum);
     return sum;
 end);
 
@@ -641,7 +641,7 @@ InstallMethod(DirectProductOp, "(FR) for two FR machines",
         function(M, N)
     local c, gen, trans, out, t, o, i, j, a, b, product, alphabet;
 
-    c := CallFuncList(LARGESTDENOMINATOR@,M);
+    c := CallFuncList(Fr.LARGESTDENOMINATOR,M);
     gen := Remove(c);
 
     alphabet := Cartesian(List(M,AlphabetOfFRObject));
@@ -664,7 +664,7 @@ InstallMethod(DirectProductOp, "(FR) for two FR machines",
     od;
     product := FRMachineNC(FRMFamily([1..Length(alphabet)]),Range(c[1]),trans,out);
     SetCorrespondence(product,c);
-    SET_NAME@(M,"x",product);
+    Fr.SET_NAME(M,"x",product);
     return product;
 end);
 
@@ -678,7 +678,7 @@ InstallMethod(TreeWreathProduct, "for two FR machines",
     while not [x0,y0] in alphabet do
         Error("(x0,y0) must be in the product of the machines' alphabets");
     od;
-    c := LARGESTDENOMINATOR@(g,h,g,Zero(g));
+    c := Fr.LARGESTDENOMINATOR(g,h,g,Zero(g));
     gen := Remove(c);
     if gen[4]=[] then
         one := One(Range(c[1]));
@@ -738,7 +738,7 @@ InstallMethod(TreeWreathProduct, "for two FR machines",
 
     m := Minimized(FRMachineNC(FRMFamily([1..Length(alphabet)]),Range(c[1]),trans,out));
     m!.Correspondence := List(c{[1..2]},x->x*Correspondence(m));
-    SET_NAME@([g,h],"~",m);
+    Fr.SET_NAME([g,h],"~",m);
     return m;
 end);
 #############################################################################
@@ -829,7 +829,7 @@ InstallMethod(Output, "(FR) for an FR machine and a state expressed as an intege
     elif i = 0 then
         return AlphabetOfFRObject(M);
     else
-        return INVERSE@(M!.output[-i]);
+        return Fr.INVERSE(M!.output[-i]);
     fi;
 end);
 
@@ -842,7 +842,7 @@ InstallMethod(Output, "(FR) for an FR machine and a state expressed as a word",
         if i > 0 then
             perm := M!.output[i]{perm};
         else
-            perm := INVERSE@(M!.output[-i]){perm};
+            perm := Fr.INVERSE(M!.output[-i]){perm};
         fi;
     od;
     return perm;
@@ -871,7 +871,7 @@ InstallMethod(Transition, "(FR) for an FR machine, a state expressed as an integ
     if i > 0 then
         return M!.transitions[i][p];
     else
-        return M!.transitions[-i][PREIMAGE@(M!.output[-i],p)];
+        return M!.transitions[-i][Fr.PREIMAGE(M!.output[-i],p)];
     fi;
 end);
 
@@ -881,11 +881,11 @@ InstallMethod(Transitions, "(FR) for an FR machine and a state expressed as an i
     if i > 0 then
         return M!.transitions[i];
     else
-        return M!.transitions[-i]{INVERSE@(M!.output[-i])};
+        return M!.transitions[-i]{Fr.INVERSE(M!.output[-i])};
     fi;
 end);
 
-BindGlobal("FRMTRANSITION@", function(M,l,p)
+Fr.FRMTRANSITION := ( function(M,l,p)
     local w, i;
     if IsMonoid(M!.free) then
         w := One(M!.free);
@@ -901,7 +901,7 @@ BindGlobal("FRMTRANSITION@", function(M,l,p)
             fi;
             p := M!.output[i][p];
         else
-            p := PREIMAGE@(M!.output[-i],p);
+            p := Fr.PREIMAGE(M!.output[-i],p);
             if w=fail then
                 w := M!.transitions[-i][p]^-1;
             else
@@ -914,12 +914,12 @@ end);
 
 InstallMethod(Transition, "(FR) for an FR machine, a state expressed as a list, and an input",
         [IsFRMachine and IsFRMachineStdRep, IsList, IsPosInt],
-        FRMTRANSITION@);
+        Fr.FRMTRANSITION);
 
 InstallMethod(Transition, "(FR) for an FR machine, a state expressed as a word, and an input",
         [IsFRMachine and IsFRMachineStdRep, IsAssocWord, IsPosInt],
         function(M, v, p)
-    return FRMTRANSITION@(M,LetterRepAssocWord(v),p);
+    return Fr.FRMTRANSITION(M,LetterRepAssocWord(v),p);
 end);
 
 InstallMethod(Transition, "(FR) for an FR machine, a state, and a list of letters",
@@ -972,7 +972,7 @@ InstallMethod(WreathRecursion, "(FR) for an FR machine",
                 fi;
                 perm := output[i]{perm};
             else
-                perm := INVERSE@(output[-i]){perm};
+                perm := Fr.INVERSE(output[-i]){perm};
                 if vector[1]=fail then
                     vector := List(transitions[-i]{perm},Inverse);
                 else
@@ -1292,9 +1292,9 @@ InstallMethod(AsGroupFRMachine, "(FR) for a group FR machine",
     return M;
 end);
 
-BindGlobal("ASGROUPFRMACHINE@", function(M)
+Fr.ASGROUPFRMACHINE := ( function(M)
     local f, N, h, s;
-    if not ForAll(M!.output,ISINVERTIBLE@) then return fail; fi;
+    if not ForAll(M!.output,Fr.ISINVERTIBLE) then return fail; fi;
     s := GeneratorsOfFRMachine(M);
     f := FreeGroup(Length(s));
     h := MagmaHomomorphismByImagesNC(M!.free,f,GeneratorsOfGroup(f));
@@ -1304,10 +1304,10 @@ BindGlobal("ASGROUPFRMACHINE@", function(M)
 end);
 InstallMethod(AsGroupFRMachine, "(FR) for a monoid FR machine",
         [IsMonoidFRMachine],
-        ASGROUPFRMACHINE@);
+        Fr.ASGROUPFRMACHINE);
 InstallMethod(AsGroupFRMachine, "(FR) for a semigroup FR machine",
         [IsSemigroupFRMachine],
-        ASGROUPFRMACHINE@);
+        Fr.ASGROUPFRMACHINE);
 
 InstallMethod(AsMonoidFRMachine, "(FR) for a group FR machine",
         [IsGroupFRMachine],
@@ -1328,7 +1328,7 @@ InstallMethod(AsMonoidFRMachine, "(FR) for a group FR machine",
     trans := List(M!.transitions,r->List(r,w->w^h));
     out := ShallowCopy(M!.output);
     for i in [1..Length(M!.transitions)] do
-        o := INVERSE@(M!.output[i]);
+        o := Fr.INVERSE(M!.output[i]);
         Add(trans,List(M!.transitions[i],w->(w^-1)^h){o});
         Add(out,o);
     od;
@@ -1380,7 +1380,7 @@ InstallMethod(AsSemigroupFRMachine, "(FR) for a group FR machine",
     trans := List(M!.transitions,r->List(r,w->w^h));
     out := ShallowCopy(M!.output);
     for i in [1..Length(M!.transitions)] do
-        o := INVERSE@(M!.output[i]);
+        o := Fr.INVERSE(M!.output[i]);
         Add(trans,List(M!.transitions[i],w->(w^-1)^h){o});
         Add(out,o);
     od;
@@ -1399,7 +1399,7 @@ InstallMethod(AsSemigroupFRMachine, "(FR) for a monoid FR machine",
     f := FreeSemigroup(Length(sM)+1);
     sN := GeneratorsOfSemigroup(f){[1..Length(sM)]};
     one := GeneratorsOfSemigroup(f)[Length(sM)+1];
-    h := MagmaHomomorphismByFunctionNC(M!.free,f,w->MAPPEDWORD@(w,sN,one));
+    h := MagmaHomomorphismByFunctionNC(M!.free,f,w->Fr.MAPPEDWORD(w,sN,one));
     trans := List(M!.transitions,r->List(r,w->w^h));
     out := ShallowCopy(M!.output);
     Add(trans,List(AlphabetOfFRObject(M),a->one));
@@ -1416,7 +1416,7 @@ InstallMethod(AsSemigroupFRMachine, "(FR) for a semigroup FR machine",
     return M;
 end);
 
-BindGlobal("HOM2MACHINE@", function(f,tester,g)
+Fr.HOM2MACHINE := ( function(f,tester,g)
     local s;
     s := Source(f);
     if not tester(s) or s<>Range(f) then
@@ -1424,25 +1424,25 @@ BindGlobal("HOM2MACHINE@", function(f,tester,g)
     fi;
     return FRMachineNC(FRMFamily([1]),s,List(g(s),x->[x^f]),List(g(s),x->[1]));
 end);
-    
+
 InstallMethod(AsGroupFRMachine, "(FR) for a group homomorphism",
         [IsGroupHomomorphism],
-        f->HOM2MACHINE@(f,IsFreeGroup,GeneratorsOfGroup));
+        f->Fr.HOM2MACHINE(f,IsFreeGroup,GeneratorsOfGroup));
 
 InstallMethod(AsMonoidFRMachine, "(FR) for a monoid homomorphism",
         [IsMagmaHomomorphism],
-        f->HOM2MACHINE@(f,IsFreeMonoid,GeneratorsOfMonoid));
+        f->Fr.HOM2MACHINE(f,IsFreeMonoid,GeneratorsOfMonoid));
 
 InstallMethod(AsSemigroupFRMachine, "(FR) for a semigroup homomorphism",
         [IsMagmaHomomorphism],
-        f->HOM2MACHINE@(f,IsFreeSemigroup,GeneratorsOfSemigroup));
+        f->Fr.HOM2MACHINE(f,IsFreeSemigroup,GeneratorsOfSemigroup));
 #############################################################################
 
 #############################################################################
 ##
 #M Minimized(FRMachine)
 ##
-BindGlobal("MINIMIZERWS_MAKERULES@", function(rws,p)
+Fr.MINIMIZERWS_MAKERULES := ( function(rws,p)
     # p is a tuple [generators,inverses,isone?,rules]
     # this command recomputes the rules
     local i, l;
@@ -1462,7 +1462,7 @@ BindGlobal("MINIMIZERWS_MAKERULES@", function(rws,p)
     fi;
 end);
 
-BindGlobal("MINIMIZERWS@", function(M)
+Fr.MINIMIZERWS := ( function(M)
     local rws, gens, h, i, j, si, p, part, newpart, changed;
 
     rws := NewFRMachineRWS(M);
@@ -1477,7 +1477,7 @@ BindGlobal("MINIMIZERWS@", function(M)
     gens := Filtered(gens,x->rws.letterrep(x)=rws.reduce(rws.letterrep(x)));
     i := List(gens,x->Output(M,x));
     si := Set(i);
-    part := List(si,x->[[],[],HasIsBuiltFromMonoid(rws.rws) and IsBuiltFromMonoid(rws.rws) and ISONE@(x)]);
+    part := List(si,x->[[],[],HasIsBuiltFromMonoid(rws.rws) and IsBuiltFromMonoid(rws.rws) and Fr.ISONE(x)]);
     for j in [1..Length(i)] do
         p := Position(si,i[j]);
         Add(part[p][1],rws.letterrep(gens[j])[1]);
@@ -1489,7 +1489,7 @@ BindGlobal("MINIMIZERWS@", function(M)
     od;
     for p in part do
         SortParallel(p[1],p[2]);
-        MINIMIZERWS_MAKERULES@(rws,p);
+        Fr.MINIMIZERWS_MAKERULES(rws,p);
     od;
 
     changed := true;
@@ -1509,7 +1509,7 @@ BindGlobal("MINIMIZERWS@", function(M)
                     Add(newpart[p][2],part[h][2][j]);
                 od;
                 for p in newpart do
-                    MINIMIZERWS_MAKERULES@(rws,p);
+                    Fr.MINIMIZERWS_MAKERULES(rws,p);
                 od;
                 Append(part,newpart);
                 part[h] := Remove(part);
@@ -1517,14 +1517,14 @@ BindGlobal("MINIMIZERWS@", function(M)
             elif part[h][3] and not ForAll(si[1],IsEmpty) then
                 changed := true;
                 part[h][3] := false;
-                MINIMIZERWS_MAKERULES@(rws,part[h]);
+                Fr.MINIMIZERWS_MAKERULES(rws,part[h]);
                 break;
             fi;
         od;
     od;
     for p in part do
         p[3] := p[3] and ForAll(p[1],x->ForAll(rws.pi([x])[1],x->rws.reduce(x)=[]));
-        MINIMIZERWS_MAKERULES@(rws,p);
+        Fr.MINIMIZERWS_MAKERULES(rws,p);
     od;
     rws.rws!.tzrules := Concatenation(rws.tzrules,Concatenation(List(part,p->p[4])));
     rws.modified := true;
@@ -1537,12 +1537,12 @@ InstallMethod(Minimized, "(FR) for a group/monoid/semigroup FR machine",
         [IsFRMachine and IsFRMachineStdRep],
         function(M)
     local rws, gens, gensimg, i, ri, red, free, freegens, one, out, trans, map;
-    rws := MINIMIZERWS@(M);
+    rws := Fr.MINIMIZERWS(M);
     gens := GeneratorsOfFRMachine(M);
     i := List(gens,rws.letterrep);
     red := Filtered(i,x->rws.reduce(x)=x);
     if i=red then
-        M := COPYFRMACHINE@(M);
+        M := Fr.COPYFRMACHINE(M);
         SetCorrespondence(M,IdentityMapping(M!.free));
         return M;
     fi;
@@ -1607,8 +1607,8 @@ InstallMethod(SubFRMachine, "(FR) for two group/monoid/semigroup FR machines",
     if (IsGroupFRMachine(N) and not IsGroupFRMachine(M)) or (IsMonoidFRMachine(N) and IsSemigroupFRMachine(M)) then
         return fail;
     fi;
-    S := FRMMINSUM@(N,M);
-    rws := MINIMIZERWS@(S);
+    S := Fr.FRMMINSUM(N,M);
+    rws := Fr.MINIMIZERWS(S);
     Mgens := GeneratorsOfSemigroup(M!.free);
     Ngens := GeneratorsOfFRMachine(N);
     Mletter := List(Mgens,x->rws.letterrep(x^Correspondence(S)[2]));
@@ -1655,7 +1655,7 @@ end);
 
 ################################################################
 # change basis of FR machine
-BindGlobal("CHANGEFRMACHINEBASIS@", function(M,l,p)
+Fr.CHANGEFRMACHINEBASIS := ( function(M,l,p)
     local trans, i, d, newM;
     d := Size(AlphabetOfFRObject(M));
     while Length(l)<>d or not ForAll(l,x->x in StateSet(M)) do
@@ -1676,21 +1676,21 @@ InstallMethod(ChangeFRMachineBasis, "(FR) for a group FR machine and a list",
         [IsGroupFRMachine, IsCollection],
         function(M,l)
     return ChangeFRMachineBasis(M,l,());
-end);	
+end);
 InstallMethod(ChangeFRMachineBasis, "(FR) for a group FR machine and a permutation",
         [IsGroupFRMachine, IsPerm],
         function(M,p)
     return ChangeFRMachineBasis(M,List(AlphabetOfFRObject(M),x->One(StateSet(M))),p);
-end);	
+end);
 InstallMethod(ChangeFRMachineBasis, "(FR) for a group FR machine, a list and a permutation",
         [IsGroupFRMachine, IsCollection, IsPerm],
-    CHANGEFRMACHINEBASIS@);
+    Fr.CHANGEFRMACHINEBASIS);
 
 InstallMethod(ChangeFRMachineBasis, "(FR) for an FR machine",
         [IsGroupFRMachine],
         function(M)
     local cycles, basis, s, t, u, v;
-    
+
     # gather all permutation cycles
     cycles := [];
     for s in GeneratorsOfFRMachine(M) do
@@ -1700,7 +1700,7 @@ InstallMethod(ChangeFRMachineBasis, "(FR) for an FR machine",
             fi;
         od;
     od;
-    
+
     basis := [];
     while cycles<>[] do
         # first cycle connected to the partial basis
@@ -1725,7 +1725,7 @@ InstallMethod(ChangeFRMachineBasis, "(FR) for an FR machine",
     return ChangeFRMachineBasis(M,basis,());
 end);
 
-BindGlobal("RIGHTACTMACHINE@", function(M,f)
+Fr.RIGHTACTMACHINE := ( function(M,f)
     local S;
     S := StateSet(M);
     if S<>Source(f) or S<>Range(f) then
@@ -1736,9 +1736,9 @@ end);
 
 InstallMethod(\*, "(FR) for an FR machine and a mapping",
         [IsFRMachine and IsFRMachineStdRep, IsMapping],
-        RIGHTACTMACHINE@);
+        Fr.RIGHTACTMACHINE);
 
-BindGlobal("LEFTACTMACHINE@", function(f,M)
+Fr.LEFTACTMACHINE := ( function(f,M)
     local S, trans, out, i, pi, x;
     S := StateSet(M);
     if S<>Source(f) or S<>Range(f) then
@@ -1747,7 +1747,7 @@ BindGlobal("LEFTACTMACHINE@", function(f,M)
     pi := WreathRecursion(M);
     trans := [];
     out := [];
-    
+
     for i in [1..Length(M!.output)] do
         x := pi(GeneratorsOfFRMachine(M)[i]^f);
         Add(trans,x[1]);
@@ -1758,9 +1758,9 @@ end);
 
 InstallMethod(\*, "(FR) for a mapping and an FR machine",
         [IsMapping, IsFRMachine and IsFRMachineStdRep],
-        LEFTACTMACHINE@);
+        Fr.LEFTACTMACHINE);
 
-BindGlobal("CONJACTMACHINE@", function(M,f)
+Fr.CONJACTMACHINE := ( function(M,f)
     local S, newS, trans, out, i, pi, x, finv;
     S := StateSet(M);
     if S<>Source(f) then
@@ -1782,6 +1782,6 @@ end);
 
 InstallMethod(\^, "(FR) for a group FR machine and a mapping",
         [IsFRMachine and IsFRMachineStdRep, IsMapping],
-        CONJACTMACHINE@);
+        Fr.CONJACTMACHINE);
 ################################################################
 

--- a/gap/group.gd
+++ b/gap/group.gd
@@ -141,7 +141,7 @@ DeclareAttribute("AlphabetOfFRSemigroup", IsFRSemigroup);
 ##     <P/>Except in the semigroup case, <C>word-i</C> is allowed to be the
 ##     empty string; and the "&lt;...&gt;" may be skipped altogether.
 ##     In the group or IMG case, each <C>word-i</C> may also contain inverses.
-##         
+##
 ##     <P/>The following example constructs the "universal Grigorchuk machine".
 ## <Example><![CDATA[
 ## gap> m := NewGroupFRMachine("a=(1,2)(3,4)(5,6)","b=<a,b,a,b,,b>",
@@ -271,11 +271,11 @@ DeclareOperation("VirtualEndomorphism",[IsFRGroup,IsObject]);
 
 #############################################################################
 ##
-#O SEARCH@
+#O Fr.SEARCH
 ##
-## <#GAPDoc Label="SEARCH@">
+## <#GAPDoc Label="Fr.SEARCH">
 ## <ManSection>
-##   <Var Name="SEARCH@"/>
+##   <Var Name="Fr.SEARCH"/>
 ##   <Description>
 ##     This variable controls the search mechanism in FR groups. It is
 ##     a record with in particular entries <C>radius</C> and <C>depth</C>.
@@ -304,7 +304,7 @@ DeclareOperation("VirtualEndomorphism",[IsFRGroup,IsObject]);
 ## </ManSection>
 ## <#/GAPDoc>
 ##
-BindGlobal("SEARCH@", rec(depth := 6, volume := 5000));
+Fr.SEARCH := ( rec(depth := 6, volume := 5000));
 #############################################################################
 
 #############################################################################

--- a/gap/group.gi
+++ b/gap/group.gi
@@ -13,24 +13,24 @@
 
 #############################################################################
 ##
-#O SEARCH@
+#O Fr.SEARCH
 ##
-SEARCH@.DEPTH := function()
+Fr.SEARCH.DEPTH := function()
     local v;
     v := ValueOption("FRdepth");
-    if v=fail then return SEARCH@.depth; else return v; fi;
+    if v=fail then return Fr.SEARCH.depth; else return v; fi;
 end;
 
-SEARCH@.VOLUME := function()
+Fr.SEARCH.VOLUME := function()
     local v;
     v := ValueOption("FRvolume");
-    if v=fail then return SEARCH@.volume; else return v; fi;
+    if v=fail then return Fr.SEARCH.volume; else return v; fi;
 end;
 
-SEARCH@.BALL := 1;
-SEARCH@.QUOTIENT := 2;
+Fr.SEARCH.BALL := 1;
+Fr.SEARCH.QUOTIENT := 2;
 
-SEARCH@.INIT := function(G)
+Fr.SEARCH.INIT := function(G)
     # initializes search structure, stored in semigroup G
     if IsBound(G!.FRData) then return; fi;
     if IsFRGroup(G) then
@@ -54,18 +54,18 @@ SEARCH@.INIT := function(G)
     fi;
 end;
 
-SEARCH@.RESET := function(G)
+Fr.SEARCH.RESET := function(G)
     Unbind(G!.FRData);
 end;
 
-SEARCH@.ERROR := function(G,str)
+Fr.SEARCH.ERROR := function(G,str)
     # allow user to increase the search limits
     local obm, volume, depth;
     obm := OnBreakMessage;
     volume := fail; depth := fail;
     OnBreakMessage := function()
-        Print("current limits are (volume = ",SEARCH@.VOLUME(),
-              ", depth = ",SEARCH@.DEPTH(),")\n",
+        Print("current limits are (volume = ",Fr.SEARCH.VOLUME(),
+              ", depth = ",Fr.SEARCH.DEPTH(),")\n",
               "to increase search volume, type 'volume := <value>; return;'\n",
               "to increase search depth, type 'depth := <value>; return;'\n",
               "type 'quit;' if you want to abort the computation.\n");
@@ -76,22 +76,22 @@ SEARCH@.ERROR := function(G,str)
     if depth <> fail then PushOptions(rec(FRdepth := depth)); fi;
 end;
 
-SEARCH@.EXTEND := function(arg)
+Fr.SEARCH.EXTEND := function(arg)
     # extend the search structure. argument1 is a group; argument2 is optional,
-    # and is SEARCH@.BALL to extend search ball radius,
-    # and is SEARCH@.QUOTIENT to extend search depth.
+    # and is Fr.SEARCH.BALL to extend search ball radius,
+    # and is Fr.SEARCH.QUOTIENT to extend search depth.
     # returns fail if the search limits do not allow extension.
     local i, j, k, l, d, r, strategy;
     d := arg[1]!.FRData;
     if Length(arg)=2 then
         strategy := [arg[2]];
     else
-        strategy := [SEARCH@.BALL,SEARCH@.QUOTIENT]; fi;
-    if d.volume>=SEARCH@.VOLUME() then
-        strategy := Difference(strategy,[SEARCH@.BALL]);
+        strategy := [Fr.SEARCH.BALL,Fr.SEARCH.QUOTIENT]; fi;
+    if d.volume>=Fr.SEARCH.VOLUME() then
+        strategy := Difference(strategy,[Fr.SEARCH.BALL]);
     fi;
-    if d.level>=SEARCH@.DEPTH() then
-        strategy := Difference(strategy,[SEARCH@.QUOTIENT]);
+    if d.level>=Fr.SEARCH.DEPTH() then
+        strategy := Difference(strategy,[Fr.SEARCH.QUOTIENT]);
     fi;
     if Length(strategy)=0 then
         return fail;
@@ -102,13 +102,13 @@ SEARCH@.EXTEND := function(arg)
             # at least 20% on each strategy
             strategy := Position(d.runtimes,Minimum(d.runtimes));
         elif d.index > d.volume^2 then
-            strategy := SEARCH@.BALL;
+            strategy := Fr.SEARCH.BALL;
         else
-            strategy := SEARCH@.QUOTIENT;
+            strategy := Fr.SEARCH.QUOTIENT;
         fi;
     fi;
     r := Runtime();
-    if strategy=SEARCH@.BALL then
+    if strategy=Fr.SEARCH.BALL then
         d.radius := d.radius+1;
         d.sphere[d.radius+1] := [];
         if IsFRGroup(arg[1]) then
@@ -139,7 +139,7 @@ SEARCH@.EXTEND := function(arg)
             d.volume := d.volume+10^9; # force quotient searches
 #            d.runtimes[strategy] := d.runtimes[strategy]+10^9; # infinity messes up arithmetic later
         fi;
-    elif strategy=SEARCH@.QUOTIENT then
+    elif strategy=Fr.SEARCH.QUOTIENT then
         d.level := d.level+1;
         d.pi := d.pifunc(arg[1],d.level);
         if IsPcpGroup(Range(d.pi)) then
@@ -154,7 +154,7 @@ SEARCH@.EXTEND := function(arg)
     return true;
 end;
 
-SEARCH@.IN := function(x,G)
+Fr.SEARCH.IN := function(x,G)
     # check in x is in G. can return true, false or fail
     if not x^G!.FRData.pi in Image(G!.FRData.pi) then
         return false;
@@ -164,7 +164,7 @@ SEARCH@.IN := function(x,G)
     return fail;
 end;
 
-SEARCH@.CONJUGATE := function(G,x,y)
+Fr.SEARCH.CONJUGATE := function(G,x,y)
     # check if x,y is conjugate in G. can return true, false or fail
     if not IsConjugate(Range(G!.FRData.pi),x^G!.FRData.pi,y^G!.FRData.pi) then
         return false;
@@ -174,7 +174,7 @@ SEARCH@.CONJUGATE := function(G,x,y)
     return fail;
 end;
 
-SEARCH@.CONJUGATE_WITNESS := function(G,x,y)
+Fr.SEARCH.CONJUGATE_WITNESS := function(G,x,y)
     # check if x,y is conjugate in G. can return a conjugator, false or fail
     local s,t;
     if not IsConjugate(Range(G!.FRData.pi),x^G!.FRData.pi,y^G!.FRData.pi) then
@@ -191,7 +191,7 @@ SEARCH@.CONJUGATE_WITNESS := function(G,x,y)
     return fail;
 end;
 
-SEARCH@.CONJUGATE_COSET := function(G,c,x,y)
+Fr.SEARCH.CONJUGATE_COSET := function(G,c,x,y)
     # check if x,y is conjugate in c can return a conjugator, false or fail
     local s,t,r,B,K,K_pi;
     B := BranchStructure(G);
@@ -218,7 +218,7 @@ SEARCH@.CONJUGATE_COSET := function(G,c,x,y)
     return fail;
 end;
 
-SEARCH@.EXTENDTRANSVERSAL := function(G,H,trans)
+Fr.SEARCH.EXTENDTRANSVERSAL := function(G,H,trans)
     # completes the tranversal trans of H^pi in G^pi, and returns it,
     # or "fail" if the search volume limit of G is too small.
     # trans is a partial transversal.
@@ -232,7 +232,7 @@ SEARCH@.EXTENDTRANSVERSAL := function(G,H,trans)
     if todo=0 then return got; fi;
     i := 1;
     while true do
-        if not IsBound(G!.FRData.sphere[i]) and SEARCH@.EXTEND(G,SEARCH@.BALL)=fail then
+        if not IsBound(G!.FRData.sphere[i]) and Fr.SEARCH.EXTEND(G,Fr.SEARCH.BALL)=fail then
             return fail;
         fi;
         for j in G!.FRData.sphere[i] do
@@ -249,7 +249,7 @@ SEARCH@.EXTENDTRANSVERSAL := function(G,H,trans)
     return fail;
 end;
 
-SEARCH@.CHECKTRANSVERSAL := function(G,H,trans)
+Fr.SEARCH.CHECKTRANSVERSAL := function(G,H,trans)
     # check that trans is a transversal of H in G.
     # returns true on success, false on failure, and fail if the search
     # volume of H is too limited.
@@ -259,7 +259,7 @@ SEARCH@.CHECKTRANSVERSAL := function(G,H,trans)
         repeat
             found := false;
             for u in transinv do
-                b := SEARCH@.IN(t*g*u,H);
+                b := Fr.SEARCH.IN(t*g*u,H);
                 if b=true then
                     found := true;
                     break;
@@ -269,7 +269,7 @@ SEARCH@.CHECKTRANSVERSAL := function(G,H,trans)
             od;
             if found=false then
                 return false;
-            elif found=fail and SEARCH@.EXTEND(H)=fail then
+            elif found=fail and Fr.SEARCH.EXTEND(H)=fail then
                 return fail;
             fi;
         until found=true;
@@ -292,7 +292,7 @@ end;
 
 # the next method is also there to cache an attribute giving the data required
 # to express group elements as words.
-if @.nql then
+if Fr.locals.nql then
     InstallMethod(FRGroupImageData, "(FR) for a FR group with preimage data",
             [IsFRGroup and HasFRGroupPreImageData],
             G->FRGroupPreImageData(G)(-1));
@@ -482,11 +482,11 @@ end);
 #O FullSCSemigroup
 #O FullSCMonoid
 ##
-FILTERORDER@ := [IsFRObject, IsFinitaryFRElement, IsBoundedFRElement, IsPolynomialGrowthFRElement, IsFiniteStateFRElement, IsFRElement];
+Fr.FILTERORDER := [IsFRObject, IsFinitaryFRElement, IsBoundedFRElement, IsPolynomialGrowthFRElement, IsFiniteStateFRElement, IsFRElement];
 # value IsFRObject means a group for which the exact category of elements is
 # not known; it really stand for "unspecified subgroup of FullSCGroup"
 
-BindGlobal("FULLGETDATA@", function(arglist,
+Fr.FULLGETDATA := ( function(arglist,
         cat, Iscat, IsFRcat, GeneratorsOfcat, AscatFRElement,
         makevertex, stype)
     local a, G, rep, alphabet, i, x, name, filter, depth, vertex, o, onerep;
@@ -498,7 +498,7 @@ BindGlobal("FULLGETDATA@", function(arglist,
         elif IsList(a) or IsDomain(a) then
             alphabet := a;
         elif IsFilter(a) then
-            if Position(FILTERORDER@,a)<Position(FILTERORDER@,filter) then filter := a; fi;
+            if Position(Fr.FILTERORDER,a)<Position(Fr.FILTERORDER,filter) then filter := a; fi;
         elif IsInt(a) then
             depth := a;
         else
@@ -601,8 +601,8 @@ BindGlobal("FULLGETDATA@", function(arglist,
             Append(name,", "); Append(name,x);
         fi;
         Append(name,")");
-        for x in [2..Position(FILTERORDER@,filter)-1] do
-            Setter(FILTERORDER@[x])(G,false);
+        for x in [2..Position(Fr.FILTERORDER,filter)-1] do
+            Setter(Fr.FILTERORDER[x])(G,false);
         od;
         SetIsStateClosed(G, true);
         SetIsRecurrentFRSemigroup(G, depth=infinity);
@@ -637,7 +637,7 @@ end);
 InstallGlobalFunction(FullSCGroup, # "(FR) full tree automorphism group",
         function(arg)
     local  G;
-    G := FULLGETDATA@(arg,Group,IsGroup,IsFRGroup,GeneratorsOfGroup,AsGroupFRElement,
+    G := Fr.FULLGETDATA(arg,Group,IsGroup,IsFRGroup,GeneratorsOfGroup,AsGroupFRElement,
                  SymmetricGroup,"Group");
     if IsTrivial(G) or FullSCFilter(G)=IsFRObject then
         return G;
@@ -655,7 +655,7 @@ end);
 InstallGlobalFunction(FullSCMonoid,
         function(arg)
     local M;
-    M := FULLGETDATA@(arg,Monoid,IsMonoid,IsFRMonoid,GeneratorsOfMonoid,AsMonoidFRElement,
+    M := Fr.FULLGETDATA(arg,Monoid,IsMonoid,IsFRMonoid,GeneratorsOfMonoid,AsMonoidFRElement,
                  FullTransformationMonoid,
                  "Monoid");
     return M;
@@ -664,7 +664,7 @@ end);
 InstallGlobalFunction(FullSCSemigroup,
         function(arg)
     local S;
-    S := FULLGETDATA@(arg,Semigroup,IsSemigroup,IsFRSemigroup,GeneratorsOfSemigroup,AsSemigroupFRElement,
+    S := Fr.FULLGETDATA(arg,Semigroup,IsSemigroup,IsFRSemigroup,GeneratorsOfSemigroup,AsSemigroupFRElement,
                  FullTransformationSemigroup,"Semigroup");
     return S;
 end);
@@ -704,7 +704,7 @@ end);
 #M  Random
 #M  Pseudorandom
 ##
-BindGlobal("RANDOMFINITARY@", function(G,d)
+Fr.RANDOMFINITARY := ( function(G,d)
     local i, a, t, transitions, output;
     if d=0 then return One(G); fi;
     transitions := [];
@@ -724,13 +724,13 @@ BindGlobal("RANDOMFINITARY@", function(G,d)
     return MealyElement(transitions,output,1);
 end);
 
-BindGlobal("RANDOMBOUNDED@", function(G)
+Fr.RANDOMBOUNDED := ( function(G)
     local E, F, M, s, n, i, j;
     if IsTrivial(G) then
         return One(G);
     fi;
     s := Size(AlphabetOfFRSemigroup(G));
-    F := RANDOMFINITARY@(G,Random([2..4]));
+    F := Fr.RANDOMFINITARY(G,Random([2..4]));
     M := UnderlyingFRMachine(F);
     for i in [0..5] do
         n := Random([1..4]);
@@ -743,18 +743,18 @@ BindGlobal("RANDOMBOUNDED@", function(G)
     return F;
 end);
 
-BindGlobal("RANDOMPOLYNOMIALGROWTH@", function(G)
+Fr.RANDOMPOLYNOMIALGROWTH := ( function(G)
     local E, F, i, j, one, n, p;
-#    F := RANDOMBOUNDED@(G);
+#    F := Fr.RANDOMBOUNDED(G);
     for i in [0..5] do
-        E := UnderlyingFRMachine(RANDOMBOUNDED@(G));
+        E := UnderlyingFRMachine(Fr.RANDOMBOUNDED(G));
         for j in [1..Random([0..4])] do
             one := First([1..E!.nrstates],i->IsOne(FRElement(E,i)));
             repeat
                 n := Random([1..E!.nrstates]);
                 p := Random([1..Size(AlphabetOfFRSemigroup(G))]);
             until E!.transitions[n][p]=one;
-            E := E+UnderlyingFRMachine(RANDOMBOUNDED@(G));
+            E := E+UnderlyingFRMachine(Fr.RANDOMBOUNDED(G));
             E!.transitions[n^Correspondence(E)[1]][p] := 1^Correspondence(E)[2];
         od;
         return FRElement(E,1);
@@ -768,13 +768,13 @@ InstallMethodWithRandomSource(Random, "for a random source and a full SC Group",
         function (rs, G)
     local n, f;
     if DepthOfFRSemigroup(G)<infinity then
-        return Minimized(RANDOMFINITARY@(G,DepthOfFRSemigroup(G)));
+        return Minimized(Fr.RANDOMFINITARY(G,DepthOfFRSemigroup(G)));
     elif IsFinitaryFRSemigroup(G) then
-        return Minimized(RANDOMFINITARY@(G,Random(rs, 0, 5)));
+        return Minimized(Fr.RANDOMFINITARY(G,Random(rs, 0, 5)));
     elif IsBoundedFRSemigroup(G) then
-        return RANDOMBOUNDED@(G);
+        return Fr.RANDOMBOUNDED(G);
     elif IsPolynomialGrowthFRSemigroup(G) then
-        return RANDOMPOLYNOMIALGROWTH@(G);
+        return Fr.RANDOMPOLYNOMIALGROWTH(G);
     elif IsFiniteStateFRSemigroup(G) then
         n := Random(rs, 1, 20);
         return MealyElement(List([1..n],s->List(AlphabetOfFRSemigroup(G),a->Random(rs, 1, n))),List([1..n],s->Random(rs, FullSCVertex(G))),1);
@@ -789,7 +789,7 @@ InstallMethodWithRandomSource(Random, "for a random source and a full SC Group",
     fi;
 end);
 
-BindGlobal("INITPSEUDORANDOM@", function(g, len, scramble)
+Fr.INITPSEUDORANDOM := ( function(g, len, scramble)
     local gens, seed, i;
     gens := GeneratorsOfSemigroup(g);
     if 0 = Length(gens) then
@@ -807,11 +807,11 @@ BindGlobal("INITPSEUDORANDOM@", function(g, len, scramble)
     od;
 end);
 
-BindGlobal("PSEUDORANDOM@", function (g)
+Fr.PSEUDORANDOM := ( function (g)
     local seed, i, j;
     if not HasPseudoRandomSeed(g) then
         i := Length( GeneratorsOfSemigroup(g) );
-        INITPSEUDORANDOM@(g, i+10, Maximum(i*10,100));
+        Fr.INITPSEUDORANDOM(g, i+10, Maximum(i*10,100));
     fi;
     seed := PseudoRandomSeed(g);
     if 0 = Length(seed[1]) then
@@ -834,7 +834,7 @@ InstallMethod(PseudoRandom, "(FR) for an FR group",
         function(g)
     local lim, gens, i, x;
     lim := ValueOption("radius");
-    if lim=fail then return PSEUDORANDOM@(g); fi;
+    if lim=fail then return Fr.PSEUDORANDOM(g); fi;
     gens := GeneratorsOfSemigroup(g);
     x := Random(gens);
     for i in [1..lim] do x := x*Random(gens); od;
@@ -866,7 +866,7 @@ InstallMethod(IsSubset, "(FR) for two full FR semigroups",
         return false;
     elif DepthOfFRSemigroup(H)<infinity then
         return true;
-    elif Position(FILTERORDER@,FullSCFilter(G))<Position(FILTERORDER@,FullSCFilter(H)) then
+    elif Position(Fr.FILTERORDER,FullSCFilter(G))<Position(Fr.FILTERORDER,FullSCFilter(H)) then
         return false;
     else
         return true;
@@ -957,12 +957,12 @@ InstallMethod(\in, "(FR) for an FR element and an FR semigroup",
             return false;
         fi;
     fi;
-    SEARCH@.INIT(G);
+    Fr.SEARCH.INIT(G);
     while true do
-        b := SEARCH@.IN(g,G);
+        b := Fr.SEARCH.IN(g,G);
         if b<>fail then return b; fi;
-        while SEARCH@.EXTEND(G)=fail do
-            SEARCH@.ERROR(G,"\\in");
+        while Fr.SEARCH.EXTEND(G)=fail do
+            Fr.SEARCH.ERROR(G,"\\in");
         od;
         Info(InfoFR, 3, "\\in: searching at level ",G!.FRData.level," and in sphere of radius ",G!.FRData.radius);
     od;
@@ -972,12 +972,12 @@ InstallMethod(IsConjugate, "(FR) for an FR element and an FR group",
         [IsFRGroup,IsFRElement, IsFRElement],
         function ( G, g, h )
     local b;
-    SEARCH@.INIT(G);
+    Fr.SEARCH.INIT(G);
     while true do
-        b := SEARCH@.CONJUGATE(G,g,h);
+        b := Fr.SEARCH.CONJUGATE(G,g,h);
         if b<>fail then return b; fi;
-        while SEARCH@.EXTEND(G)=fail do
-            SEARCH@.ERROR(G,"IsConjugate");
+        while Fr.SEARCH.EXTEND(G)=fail do
+            Fr.SEARCH.ERROR(G,"IsConjugate");
         od;
         Info(InfoFR, 3, "IsConjugate: searching at level ",G!.FRData.level," and in sphere of radius ",G!.FRData.radius);
     od;
@@ -988,24 +988,24 @@ InstallOtherMethod(RepresentativeActionOp, "(FR) for an FR element and an FR gro
         function ( G, g, h, f )
     local b;
     if f <> OnPoints then TryNextMethod(); fi;
-    SEARCH@.INIT(G);
+    Fr.SEARCH.INIT(G);
     while true do
-        b := SEARCH@.CONJUGATE_WITNESS(G,g,h);
-        if b<>fail then 
-        	if b=false 
-        		then return fail; 
-        	else 
-        		return b; 
+        b := Fr.SEARCH.CONJUGATE_WITNESS(G,g,h);
+        if b<>fail then
+        	if b=false
+        		then return fail;
+        	else
+        		return b;
         	fi;
         fi;
-        while SEARCH@.EXTEND(G)=fail do
-            SEARCH@.ERROR(G,"RepresentativeActionOp");
+        while Fr.SEARCH.EXTEND(G)=fail do
+            Fr.SEARCH.ERROR(G,"RepresentativeActionOp");
         od;
         Info(InfoFR, 3, "RepresentativeActionOp: searching at level ",G!.FRData.level," and in sphere of radius ",G!.FRData.radius);
     od;
 end);
 
-BindGlobal("EDGESTABILIZER@", function(G)
+Fr.EDGESTABILIZER := ( function(G)
     # returns the stabilizer of an edge in the tree; i.e.
     # computes the action on the second level, and takes the stabilizer of a subtree and at the root.
     local i, a, s;
@@ -1019,8 +1019,8 @@ BindGlobal("EDGESTABILIZER@", function(G)
     #s := Stabilizer(s,List(AlphabetOfFRSemigroup(G),i->(i-1)*Size(AlphabetOfFRSemigroup(G))+AlphabetOfFRSemigroup(G)),OnTuplesSets);
     return s;
 end);
-    
-BindGlobal("ISFINITE_THOMPSONWIELANDT@", function(G)
+
+Fr.ISFINITE_THOMPSONWIELANDT := ( function(G)
     # returns 'true' if G is finite, 'false' if not, 'fail' otherwise
     #
     # Thompson-Wielandt's theorem says that G is infinite if the stabilizer of a vertex is primitive
@@ -1030,7 +1030,7 @@ BindGlobal("ISFINITE_THOMPSONWIELANDT@", function(G)
 
     if HasUnderlyingFRMachine(G) and IsBireversible(UnderlyingFRMachine(G))
        and IsPrimitive(VertexTransformations(G),AlphabetOfFRSemigroup(G)) then
-        s := EDGESTABILIZER@(G);
+        s := Fr.EDGESTABILIZER(G);
         if not IsPGroup(s) then
             return false;
         fi;
@@ -1038,14 +1038,14 @@ BindGlobal("ISFINITE_THOMPSONWIELANDT@", function(G)
     return fail;
 end);
 
-BindGlobal("ISFINITE_MINIMIZEDUAL@", function(G)
+Fr.ISFINITE_MINIMIZEDUAL := ( function(G)
     # keep taking dual and minimizing, ask whether we get the trivial machine
     local gens, m, oldm;
-    
+
     if not HasGeneratorsOfGroup(G) then
         return fail;
     fi;
-    
+
     gens := GeneratorsOfGroup(G);
     if ForAll(gens,HasIsFiniteStateFRElement) and ForAll(gens,IsFiniteStateFRElement) then
         m := Sum(List(gens,UnderlyingFRMachine));
@@ -1069,25 +1069,25 @@ InstallMethod(IsFinite, "(FR) for an FR group",
     if IsFinitaryFRSemigroup(G) then
         return true;
     fi;
-    
-    b := ISFINITE_MINIMIZEDUAL@(G);
+
+    b := Fr.ISFINITE_MINIMIZEDUAL(G);
     if b<>fail then
         return b;
     fi;
 
-    b := ISFINITE_THOMPSONWIELANDT@(G);
+    b := Fr.ISFINITE_THOMPSONWIELANDT(G);
     if b<>fail then
         return b;
     fi;
-    
+
     if IsLevelTransitiveFRGroup(G) then
         return false;
     fi;
-    
+
     TryNextMethod();
 end);
 
-BindGlobal("SIZE@", function(G,testorder)
+Fr.SIZE := ( function(G,testorder)
     local n, g, iter;
     iter := Iterator(G);
     n := 0;
@@ -1123,38 +1123,38 @@ end);
 InstallMethod(Size, "(FR) for an FR semigroup",
         [IsFRSemigroup],
         function(G)
-    return SIZE@(G,false);
+    return Fr.SIZE(G,false);
 end);
 
 InstallMethod(Size, "(FR) for an FR group",
         [IsFRGroup],
         function(G)
     local b, gens, rays;
-    b := ISFINITE_THOMPSONWIELANDT@(G);
+    b := Fr.ISFINITE_THOMPSONWIELANDT(G);
     if b=true then
-        return SIZE@(G,false);
+        return Fr.SIZE(G,false);
     elif b=false then
         return infinity;
     elif IsBoundedFRSemigroup(G) then
         gens := GeneratorsOfGroup(G);
         rays := Union(List(gens,g->List(Germs(g),p->p[1])));
         if ForAll(rays,x->ForAll(gens,s->x^s=x)) then
-            return SIZE@(G,false);
+            return Fr.SIZE(G,false);
         fi;
     fi;
     if IsLevelTransitiveFRGroup(G) then return infinity; fi;
     #!!! try to find a subgroup that acts transitively on a subtree
-    return SIZE@(G,true);
+    return Fr.SIZE(G,true);
 end);
 
-SEARCH@.NEXTITERATOR := function(iter)
+Fr.SEARCH.NEXTITERATOR := function(iter)
     if iter!.pos < Length(iter!.G!.FRData.sphere[iter!.radius+1]) then
         iter!.pos := iter!.pos+1;
     else
         iter!.pos := 1;
         while iter!.radius=iter!.G!.FRData.radius and
-           SEARCH@.EXTEND(iter!.G,SEARCH@.BALL)=fail do
-            SEARCH@.ERROR(iter!.G,"NextIterator");
+           Fr.SEARCH.EXTEND(iter!.G,Fr.SEARCH.BALL)=fail do
+            Fr.SEARCH.ERROR(iter!.G,"NextIterator");
         od;
         iter!.radius := iter!.radius+1;
         if iter!.G!.FRData.sphere[iter!.radius+1]=[] then return fail; fi;
@@ -1162,52 +1162,52 @@ SEARCH@.NEXTITERATOR := function(iter)
     return iter!.G!.FRData.sphere[iter!.radius+1][iter!.pos];
 end;
 
-SEARCH@.ISDONEITERATOR := function(iter)
+Fr.SEARCH.ISDONEITERATOR := function(iter)
     if iter!.pos < Length(iter!.G!.FRData.sphere[iter!.radius+1]) then
         return false;
     else
         iter!.pos := 0;
         while iter!.radius=iter!.G!.FRData.radius and
-           SEARCH@.EXTEND(iter!.G,SEARCH@.BALL)=fail do
-            SEARCH@.ERROR(iter!.G,"IsDoneIterator");
+           Fr.SEARCH.EXTEND(iter!.G,Fr.SEARCH.BALL)=fail do
+            Fr.SEARCH.ERROR(iter!.G,"IsDoneIterator");
         od;
         iter!.radius := iter!.radius+1;
         return iter!.G!.FRData.sphere[iter!.radius+1]=[];
     fi;
 end;
 
-SEARCH@.SHALLOWCOPY := function(iter)
+Fr.SEARCH.SHALLOWCOPY := function(iter)
     return rec(
-               NextIterator := SEARCH@.NEXTITERATOR,
-               IsDoneIterator := SEARCH@.ISDONEITERATOR,
-               ShallowCopy := SEARCH@.SHALLOWCOPY,
+               NextIterator := Fr.SEARCH.NEXTITERATOR,
+               IsDoneIterator := Fr.SEARCH.ISDONEITERATOR,
+               ShallowCopy := Fr.SEARCH.SHALLOWCOPY,
                G := iter!.G,
                pos := iter!.pos,
                radius := iter!.radius);
 end;
 
-SEARCH@.ELEMENTNUMBER := function(iter,n)
+Fr.SEARCH.ELEMENTNUMBER := function(iter,n)
     local i;
     i := 1;
     while n > Length(iter!.G!.FRData.sphere[i]) do
         n := n-Length(iter!.G!.FRData.sphere[i]);
         i := i+1;
         while not IsBound(iter!.G!.FRData.sphere[i]) and
-           SEARCH@.EXTEND(iter!.G,SEARCH@.BALL)=fail do
-            SEARCH@.ERROR(iter!.G,"ElementNumber");
+           Fr.SEARCH.EXTEND(iter!.G,Fr.SEARCH.BALL)=fail do
+            Fr.SEARCH.ERROR(iter!.G,"ElementNumber");
         od;
         if iter!.G!.FRData.sphere[i]=[] then return fail; fi;
     od;
     return iter!.G!.FRData.sphere[i][n];
 end;
 
-SEARCH@.NUMBERELEMENT := function(iter,x)
+Fr.SEARCH.NUMBERELEMENT := function(iter,x)
     local i, n, p;
     i := 1; n := 0;
     repeat
         while not IsBound(iter!.G!.FRData.sphere[i]) and
-           SEARCH@.EXTEND(iter!.G,SEARCH@.BALL)=fail do
-            SEARCH@.ERROR(iter!.G,"NumberElement");
+           Fr.SEARCH.EXTEND(iter!.G,Fr.SEARCH.BALL)=fail do
+            Fr.SEARCH.ERROR(iter!.G,"NumberElement");
         od;
         p := Position(iter!.G!.FRData.sphere[i],x);
         if p<>fail then return n+p; fi;
@@ -1219,11 +1219,11 @@ end;
 InstallMethod(Iterator, "(FR) for an FR semigroup",
         [IsFRSemigroup],
         function(G)
-    SEARCH@.INIT(G);
+    Fr.SEARCH.INIT(G);
     return IteratorByFunctions(rec(
-                   NextIterator := SEARCH@.NEXTITERATOR,
-                   IsDoneIterator := SEARCH@.ISDONEITERATOR,
-                   ShallowCopy := SEARCH@.SHALLOWCOPY,
+                   NextIterator := Fr.SEARCH.NEXTITERATOR,
+                   IsDoneIterator := Fr.SEARCH.ISDONEITERATOR,
+                   ShallowCopy := Fr.SEARCH.SHALLOWCOPY,
                    G := G,
                    pos := 0,
                    radius := 0));
@@ -1273,10 +1273,10 @@ end);
 InstallMethod(Enumerator, "(FR) for an FR semigroup",
         [IsFRSemigroup],
         function(G)
-    SEARCH@.INIT(G);
+    Fr.SEARCH.INIT(G);
     return EnumeratorByFunctions(G,rec(
-                   ElementNumber := SEARCH@.ELEMENTNUMBER,
-                   NumberElement := SEARCH@.NUMBERELEMENT,
+                   ElementNumber := Fr.SEARCH.ELEMENTNUMBER,
+                   NumberElement := Fr.SEARCH.NUMBERELEMENT,
                    G := G));
 end);
 
@@ -1298,7 +1298,7 @@ end);
 ##
 #M View
 ##
-BindGlobal("VIEWFRGROUP@", function(G,gens,name)
+Fr.VIEWFRGROUP := ( function(G,gens,name)
     local n, s;
     s := "<";
     if HasIsStateClosed(G) then
@@ -1329,28 +1329,28 @@ BindGlobal("VIEWFRGROUP@", function(G,gens,name)
         Append(s,", branched");
     fi;
     n := Length(gens(G));
-    APPEND@(s," ",name," over ",AlphabetOfFRSemigroup(G)," with ",n," generator");
+    Fr.APPEND(s," ",name," over ",AlphabetOfFRSemigroup(G)," with ",n," generator");
     if n<>1 then Append(s,"s"); fi;
-    if HasSize(G) then APPEND@(s,", of size ",Size(G)); fi;
+    if HasSize(G) then Fr.APPEND(s,", of size ",Size(G)); fi;
     Append(s,">");
     return s;
 end);
 
 InstallMethod(ViewString, "(FR) for an FR group",
         [IsFRGroup and IsFinitelyGeneratedGroup],
-        G->VIEWFRGROUP@(G,GeneratorsOfGroup,"group"));
+        G->Fr.VIEWFRGROUP(G,GeneratorsOfGroup,"group"));
 
 InstallMethod(ViewString, "(FR) for an FR monoid",
         [IsFRMonoid],
-        G->VIEWFRGROUP@(G,GeneratorsOfMonoid,"monoid"));
+        G->Fr.VIEWFRGROUP(G,GeneratorsOfMonoid,"monoid"));
 
 InstallMethod(ViewString, "(FR) for an FR semigroup",
         [IsFRSemigroup],
-        G->VIEWFRGROUP@(G,GeneratorsOfSemigroup,"semigroup"));
+        G->Fr.VIEWFRGROUP(G,GeneratorsOfSemigroup,"semigroup"));
 
-INSTALLPRINTERS@(IsFRGroup);
-INSTALLPRINTERS@(IsFRMonoid);
-INSTALLPRINTERS@(IsFRSemigroup);
+Fr.INSTALLPRINTERS(IsFRGroup);
+Fr.INSTALLPRINTERS(IsFRMonoid);
+Fr.INSTALLPRINTERS(IsFRSemigroup);
 #############################################################################
 
 #############################################################################
@@ -1466,7 +1466,7 @@ InstallMethod(EpimorphismPermGroup, "(FR) for a full FR group and a level",
     return q;
 end);
 
-BindGlobal("PERMTRANS2COLL@", function(l)
+Fr.PERMTRANS2COLL := ( function(l)
     local i;
     if IsCollection(l) then
         return l;
@@ -1478,7 +1478,7 @@ BindGlobal("PERMTRANS2COLL@", function(l)
     fi;
 end);
 
-BindGlobal("TRANSMONOID@", function(g,n,gens,filt,fullconstr,mconstr,constr,subconstr,activity)
+Fr.TRANSMONOID := ( function(g,n,gens,filt,fullconstr,mconstr,constr,subconstr,activity)
     local s;
     if ForAny(filt,x->x(g)) then
         s := gens(g);
@@ -1490,13 +1490,13 @@ BindGlobal("TRANSMONOID@", function(g,n,gens,filt,fullconstr,mconstr,constr,subc
     if s=[] then # GAP hates monoids and semigroups with 0 generators
         return subconstr(mconstr(constr([1..Size(AlphabetOfFRSemigroup(g))^n])),[]);
     fi;
-    return mconstr(PERMTRANS2COLL@(List(s,x->activity(x,n))));
+    return mconstr(Fr.PERMTRANS2COLL(List(s,x->activity(x,n))));
 end);
 
 InstallMethod(TransformationMonoid, "(FR) for a f.g. FR monoid and a level",
         [IsFRMonoid, IsInt],
         function(g, n)
-    return TRANSMONOID@(g,n,GeneratorsOfMonoid,[HasGeneratorsOfMonoid,HasGeneratorsOfGroup],FullSCMonoid,Monoid,Transformation,Submonoid,ActivityTransformation);
+    return Fr.TRANSMONOID(g,n,GeneratorsOfMonoid,[HasGeneratorsOfMonoid,HasGeneratorsOfGroup],FullSCMonoid,Monoid,Transformation,Submonoid,ActivityTransformation);
 end);
 
 InstallMethod(EpimorphismTransformationMonoid, "(FR) for a f.g. FR monoid and a level",
@@ -1512,7 +1512,7 @@ end);
 InstallMethod(TransformationSemigroup, "(FR) for a f.g. FR semigroup and a level",
         [IsFRSemigroup, IsInt],
         function(g, n)
-    return TRANSMONOID@(g,n,GeneratorsOfSemigroup,[HasGeneratorsOfSemigroup,HasGeneratorsOfMonoid,HasGeneratorsOfGroup],FullSCSemigroup,Semigroup,Transformation,Subsemigroup,ActivityTransformation);
+    return Fr.TRANSMONOID(g,n,GeneratorsOfSemigroup,[HasGeneratorsOfSemigroup,HasGeneratorsOfMonoid,HasGeneratorsOfGroup],FullSCSemigroup,Semigroup,Transformation,Subsemigroup,ActivityTransformation);
 end);
 
 InstallMethod(EpimorphismTransformationSemigroup, "(FR) for a f.g. FR semigroup and a level",
@@ -1569,16 +1569,16 @@ end);
 
 InstallMethod(NucleusOfFRSemigroup, "(FR) for an FR semigroup",
         [IsFRSemigroup],
-        G->NUCLEUS@(GeneratorsOfSemigroup(G)));
+        G->Fr.NUCLEUS(GeneratorsOfSemigroup(G)));
 
 InstallMethod(NucleusMachine, "(FR) for an FR semigroup",
         [IsFRSemigroup],
         G->AsMealyMachine(NucleusOfFRSemigroup(G)));
 
-BindGlobal("ADJACENCYBASESWITHONE@",
+Fr.ADJACENCYBASESWITHONE := (
         function(nuke)
     local seen, i, j, a, len, u, bases, basepos, machine, skip, addelt;
-    
+
     addelt := function(new)
         local i;
         i := 1;
@@ -1595,10 +1595,10 @@ BindGlobal("ADJACENCYBASESWITHONE@",
         Add(bases,new);
         return true;
     end;
-    
+
     nuke := Set(nuke);
     machine := AsMealyMachine(nuke);
-    
+
     seen := [[[1..Length(nuke)],[],false]];
     bases := [];
     len := 1;
@@ -1624,7 +1624,7 @@ BindGlobal("ADJACENCYBASESWITHONE@",
         od;
         len := len+1;
     od;
-    
+
     basepos := 1;
     while basepos <= Length(bases) do
         for i in AlphabetOfFRObject(machine) do
@@ -1637,20 +1637,20 @@ end);
 
 InstallMethod(AdjacencyBasesWithOne, "(FR) for a nucleus",
         [IsFRElementCollection],
-        L->ADJACENCYBASESWITHONE@(L)[3]);
+        L->Fr.ADJACENCYBASESWITHONE(L)[3]);
 
 InstallMethod(AdjacencyBasesWithOne, "(FR) for an FR semigroup",
         [IsFRSemigroup],
-        G->ADJACENCYBASESWITHONE@(NucleusOfFRSemigroup(G))[3]);
+        G->Fr.ADJACENCYBASESWITHONE(NucleusOfFRSemigroup(G))[3]);
 
-BindGlobal("ADJACENCYPOSET@",
+Fr.ADJACENCYPOSET := (
         function(nuke)
     local b, c, x, y, elements, oldelements, rel, bases, dom;
-    
-    bases := ADJACENCYBASESWITHONE@(nuke);
+
+    bases := Fr.ADJACENCYBASESWITHONE(nuke);
     nuke := bases[2];
     bases := bases[1];
-    
+
     elements := [];
     for b in bases do
 #        for x in b do # that would be to include adjacent tiles in the relation
@@ -1675,22 +1675,22 @@ end);
 
 InstallMethod(AdjacencyPoset, "(FR) for a nucleus",
         [IsFRElementCollection],
-        ADJACENCYPOSET@);
+        Fr.ADJACENCYPOSET);
 
 InstallMethod(AdjacencyPoset, "(FR) for an FR semigroup",
         [IsFRSemigroup],
-        G->ADJACENCYPOSET@(NucleusOfFRSemigroup(G)));
+        G->Fr.ADJACENCYPOSET(NucleusOfFRSemigroup(G)));
 #############################################################################
 
 #############################################################################
 ##
 #M  Degree
 ##
-BindGlobal("FILTERCOMPARE@", function(G,filter)
+Fr.FILTERCOMPARE := ( function(G,filter)
     if FullSCFilter(G)=IsFRObject then
         TryNextMethod();
     fi;
-    return Position(FILTERORDER@,FullSCFilter(G))<=Position(FILTERORDER@,filter);
+    return Position(Fr.FILTERORDER,FullSCFilter(G))<=Position(Fr.FILTERORDER,filter);
 end);
 
 InstallMethod(DegreeOfFRSemigroup, "(FR) for a self-similar semigroup",
@@ -1716,7 +1716,7 @@ InstallMethod(IsFinitaryFRSemigroup, "(FR) for a self-similar semigroup",
         G->ForAll(GeneratorsOfSemigroup(G),IsFinitaryFRElement));
 InstallMethod(IsFinitaryFRSemigroup, "(FR) for a full SC semigroup",
         [IsFRSemigroup and HasFullSCData],
-        G->FILTERCOMPARE@(G,IsFinitaryFRElement));
+        G->Fr.FILTERCOMPARE(G,IsFinitaryFRElement));
 
 InstallMethod(IsWeaklyFinitaryFRSemigroup, "(FR) for a self-similar semigroup",
         [IsFRSemigroup],
@@ -1733,21 +1733,21 @@ InstallMethod(IsBoundedFRSemigroup, "(FR) for a self-similar semigroup",
         G->ForAll(GeneratorsOfSemigroup(G),IsBoundedFRElement));
 InstallMethod(IsBoundedFRSemigroup, "(FR) for a full SC semigroup",
         [IsFRSemigroup and HasFullSCData],
-        G->FILTERCOMPARE@(G,IsBoundedFRElement));
+        G->Fr.FILTERCOMPARE(G,IsBoundedFRElement));
 
 InstallMethod(IsPolynomialGrowthFRSemigroup, "(FR) for a self-similar semigroup",
         [IsFRSemigroup],
         G->ForAll(GeneratorsOfSemigroup(G),IsPolynomialGrowthFRElement));
 InstallMethod(IsPolynomialGrowthFRSemigroup, "(FR) for a full SC semigroup",
         [IsFRSemigroup and HasFullSCData],
-        G->FILTERCOMPARE@(G,IsPolynomialGrowthFRElement));
+        G->Fr.FILTERCOMPARE(G,IsPolynomialGrowthFRElement));
 
 InstallMethod(IsFiniteStateFRSemigroup, "(FR) for a self-similar semigroup",
         [IsFRSemigroup],
         G->ForAll(GeneratorsOfSemigroup(G),IsFiniteStateFRElement));
 InstallMethod(IsFiniteStateFRSemigroup, "(FR) for a full SC semigroup",
         [IsFRSemigroup and HasFullSCData],
-        G->FILTERCOMPARE@(G,IsFiniteStateFRElement));
+        G->Fr.FILTERCOMPARE(G,IsFiniteStateFRElement));
 #############################################################################
 
 #############################################################################
@@ -1811,7 +1811,7 @@ InstallMethod(IsSQUniversal, "(FR) for an amenable group",
     TryNextMethod();
 end);
 
-BindGlobal("TORSIONSTATES@", function(g)
+Fr.TORSIONSTATES := ( function(g)
     local s, todo, i, j, x, y;
     todo := [g];
     i := 1;
@@ -1831,11 +1831,11 @@ BindGlobal("TORSIONSTATES@", function(g)
     return todo;
 end);
 
-BindGlobal("TORSIONLIMITSTATES@", function(L)
+Fr.TORSIONLIMITSTATES := ( function(L)
     local s, d, dd, S, oldS, i, x;
     s := [];
     for i in L do
-        x := TORSIONSTATES@(i);
+        x := Fr.TORSIONSTATES(i);
         if x=fail then return fail; fi;
         UniteSet(s,x);
     od;
@@ -1856,11 +1856,11 @@ BindGlobal("TORSIONLIMITSTATES@", function(L)
     return Set(s{S});
 end);
 
-BindGlobal("TORSIONNUCLEUS@", function(G)
+Fr.TORSIONNUCLEUS := ( function(G)
     local s, olds, news, gens, i, j;
 
     gens := Set(GeneratorsOfSemigroup(G));
-    s := TORSIONLIMITSTATES@(gens);
+    s := Fr.TORSIONLIMITSTATES(gens);
     if s=fail then return fail; fi;
     olds := [];
     repeat
@@ -1869,7 +1869,7 @@ BindGlobal("TORSIONNUCLEUS@", function(G)
         for i in news do
             for j in gens do AddSet(s,i*j); od;
         od;
-        s := TORSIONLIMITSTATES@(s);
+        s := Fr.TORSIONLIMITSTATES(s);
         if s=fail then return fail; fi;
         Info(InfoFR, 2, "TorsionNucleus: The nucleus contains at least ",s);
     until olds=s;
@@ -1882,7 +1882,7 @@ InstallMethod(IsTorsionGroup, "(FR) for a self-similar group",
         [IsFRGroup],
         function(G)
     Info(InfoFR,1,"Beware! This code has not been tested nor proven valid!");
-    return TORSIONNUCLEUS@(G)<>fail;
+    return Fr.TORSIONNUCLEUS(G)<>fail;
 end);
 
 InstallMethod(IsTorsionFreeGroup, "(FR) for a self-similar group",
@@ -1931,7 +1931,7 @@ InstallMethod(IsAmenableGroup, [IsFreeGroup],
 #F  FRSemigroup
 #F  FRMonoid
 ##
-BindGlobal("STRING_ATOM2GAP@", function(s)
+Fr.STRING_ATOM2GAP := ( function(s)
     local stream, result;
     stream := "return ";
     Append(stream,s);
@@ -1944,7 +1944,7 @@ end);
 # gens: list of strings corresponding to generator names
 # imgs: a list of the same length as imgs
 # w: a string containing an expression in terms of the generators names in `gens`
-BindGlobal("STRING_WORD2GAP@", function(gens,imgs,w)
+Fr.STRING_WORD2GAP := ( function(gens,imgs,w)
     local s, f, i, argname;
     # generate an identifier that is definitely not in gens by making it
     # longer than any element of gens
@@ -1966,9 +1966,9 @@ BindGlobal("STRING_WORD2GAP@", function(gens,imgs,w)
     # ... and evaluate it at the given input
     return f(imgs);
 end);
-BindGlobal("STRING_TRANSFORMATION2GAP@", function(t,data)
+Fr.STRING_TRANSFORMATION2GAP := ( function(t,data)
     local p;
-    p := STRING_ATOM2GAP@(t);
+    p := Fr.STRING_ATOM2GAP(t);
     if IsPerm(p) then
         p := ListPerm(p);
     elif IsTransformation(p) then
@@ -1977,15 +1977,15 @@ BindGlobal("STRING_TRANSFORMATION2GAP@", function(t,data)
     data.degree := Maximum(data.degree,Length(p),MaximumList(p,0));
     return p;
 end);
-BindGlobal("STRING_GROUP@", function(freecreator, s_generator, creator, args)
+Fr.STRING_GROUP := ( function(freecreator, s_generator, creator, args)
     local temp, i, gens, states, action, mgens, data, category, machine, group;
-    
+
     if not IsString(args[Length(args)]) then
         category := Remove(args);
     else
         category := IsFRObject;
     fi;
-    
+
     if args=[] or not ForAll(args,IsString) then
         Error("<arg> should be a non-empty sequence of strings\n");
     fi;
@@ -2004,7 +2004,7 @@ BindGlobal("STRING_GROUP@", function(freecreator, s_generator, creator, args)
     for temp in List(temp,x->x[2]) do
         temp := SplitString(temp,"<");
         if Size(temp)=1 then
-            Add(action,STRING_TRANSFORMATION2GAP@(temp[1],data));
+            Add(action,Fr.STRING_TRANSFORMATION2GAP(temp[1],data));
             Add(states,[]);
         elif Size(temp)=2 and temp[1]="" then
             temp := SplitString(temp[2],">");
@@ -2013,9 +2013,9 @@ BindGlobal("STRING_GROUP@", function(freecreator, s_generator, creator, args)
             elif Size(temp)=1 then
                 Add(action,[]);
             else
-                Add(action,STRING_TRANSFORMATION2GAP@(temp[2],data));
+                Add(action,Fr.STRING_TRANSFORMATION2GAP(temp[2],data));
             fi;
-            temp := STRING_WORD2GAP@(gens,s_generator(data.holder),Concatenation("[",temp[1],"]"));
+            temp := Fr.STRING_WORD2GAP(gens,s_generator(data.holder),Concatenation("[",temp[1],"]"));
             for i in [1..Length(temp)] do
                 if not IsBound(temp[i]) or temp[i]=1 then
                     if IsMagmaWithOne(data.holder) then
@@ -2031,7 +2031,7 @@ BindGlobal("STRING_GROUP@", function(freecreator, s_generator, creator, args)
             Error("<arg> should have the form g=<...\n");
         fi;
     od;
-    
+
     for i in action do
         for temp in [1..data.degree] do
             if not IsBound(i[temp]) then
@@ -2048,7 +2048,7 @@ BindGlobal("STRING_GROUP@", function(freecreator, s_generator, creator, args)
             fi;
         od;
     od;
-    if freecreator=FreeGroup and not ForAll(action,ISINVERTIBLE@) then
+    if freecreator=FreeGroup and not ForAll(action,Fr.ISINVERTIBLE) then
         Error("<arg> should have the form g=<...>permutation\n");
     fi;
     machine := FRMachine(data.holder,states,action);
@@ -2076,37 +2076,37 @@ end);
 
 InstallGlobalFunction(FRGroup,
         function(arg)
-    return STRING_GROUP@(FreeGroup, GeneratorsOfGroup, Group, arg);
+    return Fr.STRING_GROUP(FreeGroup, GeneratorsOfGroup, Group, arg);
 end);
 
 InstallGlobalFunction(FRMonoid,
         function(arg)
-    return STRING_GROUP@(FreeMonoid, GeneratorsOfMonoid, Monoid, arg);
+    return Fr.STRING_GROUP(FreeMonoid, GeneratorsOfMonoid, Monoid, arg);
 end);
 
 InstallGlobalFunction(FRSemigroup,
         function(arg)
-    return STRING_GROUP@(FreeSemigroup, GeneratorsOfSemigroup, Semigroup, arg);
+    return Fr.STRING_GROUP(FreeSemigroup, GeneratorsOfSemigroup, Semigroup, arg);
 end);
 
 InstallGlobalFunction(NewSemigroupFRMachine,
         function(arg)
     if Length(arg)=1 and HasIsSemigroupFRMachine(arg[1]) and IsSemigroupFRMachine(arg[1]) then
-        return COPYFRMACHINE@(arg[1]);
+        return Fr.COPYFRMACHINE(arg[1]);
     fi;
     return UnderlyingFRMachine(CallFuncList(FRSemigroup,Concatenation(arg,[IsFRElement])).1);
 end);
 InstallGlobalFunction(NewMonoidFRMachine,
         function(arg)
     if Length(arg)=1 and HasIsMonoidFRMachine(arg[1]) and IsMonoidFRMachine(arg[1]) then
-        return COPYFRMACHINE@(arg[1]);
+        return Fr.COPYFRMACHINE(arg[1]);
     fi;
     return UnderlyingFRMachine(CallFuncList(FRMonoid,Concatenation(arg,[IsFRElement])).1);
 end);
 InstallGlobalFunction(NewGroupFRMachine,
         function(arg)
     if Length(arg)=1 and HasIsGroupFRMachine(arg[1]) and IsGroupFRMachine(arg[1]) then
-        return COPYFRMACHINE@(arg[1]);
+        return Fr.COPYFRMACHINE(arg[1]);
     fi;
     return UnderlyingFRMachine(CallFuncList(FRGroup,Concatenation(arg,[IsFRElement])).1);
 end);
@@ -2181,7 +2181,7 @@ InstallMethod(FRGroupByVirtualEndomorphism, "(FR) for a virtual endomorphism and
                 od;
                 Add(trans,t);
                 Add(out,o);
-                if not ISINVERTIBLE@(o) then return fail; fi;
+                if not Fr.ISINVERTIBLE(o) then return fail; fi;
                 i := i+1;
                 if RemInt(i,10)=0 then
                     Info(InfoFR, 2, "FRGroupByVirtualEndomorphism: at least ",i," states");
@@ -2212,7 +2212,7 @@ end);
 #F  IsomorphismFRGroup( <arg> )
 #F  IsomorphismMealyGroup( <arg> )
 ##
-BindGlobal("ISOMORPHICFRGENS@", function(g,iso)
+Fr.ISOMORPHICFRGENS := ( function(g,iso)
     local m, e, i, f, gens;
 
     m := fail;
@@ -2246,44 +2246,44 @@ end);
 InstallMethod(FRMachineFRGroup, "(FR) for a state-closed group",
         [IsFRGroup],
         function(G)
-    return ISOMORPHICFRGENS@(GeneratorsOfGroup(G),AsGroupFRElement)[1];
+    return Fr.ISOMORPHICFRGENS(GeneratorsOfGroup(G),AsGroupFRElement)[1];
 end);
 
 InstallMethod(FRMachineFRMonoid, "(FR) for a state-closed monoid",
         [IsFRMonoid],
         function(G)
-    return ISOMORPHICFRGENS@(GeneratorsOfMonoid(G),AsMonoidFRElement)[1];
+    return Fr.ISOMORPHICFRGENS(GeneratorsOfMonoid(G),AsMonoidFRElement)[1];
 end);
 
 InstallMethod(FRMachineFRSemigroup, "(FR) for a state-closed semigroup",
         [IsFRSemigroup],
         function(G)
-    return ISOMORPHICFRGENS@(GeneratorsOfSemigroup(G),AsSemigroupFRElement)[1];
+    return Fr.ISOMORPHICFRGENS(GeneratorsOfSemigroup(G),AsSemigroupFRElement)[1];
 end);
 
 InstallMethod(MealyMachineFRGroup, "(FR) for a state-closed group",
         [IsFRGroup],
         function(G)
-    return ISOMORPHICFRGENS@(GeneratorsOfGroup(G),AsMealyElement)[1];
+    return Fr.ISOMORPHICFRGENS(GeneratorsOfGroup(G),AsMealyElement)[1];
 end);
 
 InstallMethod(MealyMachineFRMonoid, "(FR) for a state-closed monoid",
         [IsFRMonoid],
         function(G)
-    return ISOMORPHICFRGENS@(GeneratorsOfMonoid(G),AsMealyElement)[1];
+    return Fr.ISOMORPHICFRGENS(GeneratorsOfMonoid(G),AsMealyElement)[1];
 end);
 
 InstallMethod(MealyMachineFRSemigroup, "(FR) for a state-closed semigroup",
         [IsFRSemigroup],
         function(G)
-    return ISOMORPHICFRGENS@(GeneratorsOfSemigroup(G),AsMealyElement)[1];
+    return Fr.ISOMORPHICFRGENS(GeneratorsOfSemigroup(G),AsMealyElement)[1];
 end);
 
 InstallMethod(IsomorphismFRGroup, "(FR) for a self-similar group",
         [IsFRGroup],
         function(G)
     local gens;
-    gens := ISOMORPHICFRGENS@(GeneratorsOfGroup(G),AsGroupFRElement)[2];
+    gens := Fr.ISOMORPHICFRGENS(GeneratorsOfGroup(G),AsGroupFRElement)[2];
     return GroupHomomorphismByImagesNC(G,Group(gens),GeneratorsOfGroup(G),gens);
 end);
 
@@ -2291,17 +2291,17 @@ InstallMethod(IsomorphismFRMonoid, "(FR) for a self-similar monoid",
         [IsFRMonoid],
         function(G)
     return MagmaHomomorphismByFunctionNC(G,
-                   Monoid(ISOMORPHICFRGENS@(GeneratorsOfMonoid(G),AsMonoidFRElement)[2]),AsMonoidFRElement);
+                   Monoid(Fr.ISOMORPHICFRGENS(GeneratorsOfMonoid(G),AsMonoidFRElement)[2]),AsMonoidFRElement);
 end);
 
 InstallMethod(IsomorphismFRSemigroup, "(FR) for a self-similar semigroup",
         [IsFRSemigroup],
         function(G)
     return MagmaHomomorphismByFunctionNC(G,
-                   Semigroup(ISOMORPHICFRGENS@(GeneratorsOfSemigroup(G),AsSemigroupFRElement)[2]),AsSemigroupFRElement);
+                   Semigroup(Fr.ISOMORPHICFRGENS(GeneratorsOfSemigroup(G),AsSemigroupFRElement)[2]),AsSemigroupFRElement);
 end);
 
-BindGlobal("ISOMORPHISMMEALYXXX@", function(G,gens,cons)
+Fr.ISOMORPHISMMEALYXXX := ( function(G,gens,cons)
     local H, Hgens, m, states, g;
     states := [];
     Hgens := ShallowCopy(gens(G));
@@ -2314,7 +2314,7 @@ BindGlobal("ISOMORPHISMMEALYXXX@", function(G,gens,cons)
         return IdentityMapping(G);
     fi;
     states := States(states);
-    m := MAKEMEALYMACHINE@(FamilyObj(states[1]),states,fail);
+    m := Fr.MAKEMEALYMACHINE(FamilyObj(states[1]),states,fail);
     for g in [1..Length(Hgens)] do
         if not IsMealyElement(Hgens[g]) then
             Hgens[g] := FRElement(m,Position(states,Hgens[g]));
@@ -2326,15 +2326,15 @@ end);
 
 InstallMethod(IsomorphismMealyGroup, "(FR) for a self-similar group",
         [IsFRGroup],
-        G->ISOMORPHISMMEALYXXX@(G,GeneratorsOfGroup,Group));
+        G->Fr.ISOMORPHISMMEALYXXX(G,GeneratorsOfGroup,Group));
 
 InstallMethod(IsomorphismMealyMonoid, "(FR) for a self-similar monoid",
         [IsFRMonoid],
-        G->ISOMORPHISMMEALYXXX@(G,GeneratorsOfMonoid,Monoid));
+        G->Fr.ISOMORPHISMMEALYXXX(G,GeneratorsOfMonoid,Monoid));
 
 InstallMethod(IsomorphismMealySemigroup, "(FR) for a self-similar semigroup",
         [IsFRSemigroup],
-        G->ISOMORPHISMMEALYXXX@(G,GeneratorsOfSemigroup,Semigroup));
+        G->Fr.ISOMORPHISMMEALYXXX(G,GeneratorsOfSemigroup,Semigroup));
 #############################################################################
 
 #############################################################################
@@ -2348,12 +2348,12 @@ InstallMethod(IsStateClosed, "(FR) for a self-similar group",
         [IsFRGroup and HasGeneratorsOfGroup],
         function(G)
     local g, x, b;
-    SEARCH@.INIT(G);
+    Fr.SEARCH.INIT(G);
     for g in GeneratorsOfGroup(G) do for x in DecompositionOfFRElement(g)[1] do
         while true do
-            b := SEARCH@.IN(x,G);
+            b := Fr.SEARCH.IN(x,G);
             if b=false then return false; elif b=true then break; fi;
-            if SEARCH@.EXTEND(G)=fail then return fail; fi;
+            if Fr.SEARCH.EXTEND(G)=fail then return fail; fi;
             Info(InfoFR, 3, "IsStateClosed: searching at level ",G!.FRData.level," and in sphere of radius ",G!.FRData.radius);
         od;
     od; od;
@@ -2482,20 +2482,20 @@ InstallMethod(RightCosetsNC, "(FR) for two self-similar groups",
         function(G,H)
     local trans, b;
     trans := [One(G)];
-    SEARCH@.INIT(G);
-    SEARCH@.INIT(H);
+    Fr.SEARCH.INIT(G);
+    Fr.SEARCH.INIT(H);
     repeat
-        while SEARCH@.EXTENDTRANSVERSAL(G,H,trans)=fail do
-           SEARCH@.ERROR(G,"RightCosets");
+        while Fr.SEARCH.EXTENDTRANSVERSAL(G,H,trans)=fail do
+           Fr.SEARCH.ERROR(G,"RightCosets");
         od;
-        b := SEARCH@.CHECKTRANSVERSAL(G,H,trans);
+        b := Fr.SEARCH.CHECKTRANSVERSAL(G,H,trans);
         if b=fail then
             return fail;
         elif b=true then
             return List(trans,x->RightCoset(H,x));
         else
-            while SEARCH@.EXTEND(G,SEARCH@.QUOTIENT)=fail do
-                SEARCH@.ERROR(G,"RightCosets");
+            while Fr.SEARCH.EXTEND(G,Fr.SEARCH.QUOTIENT)=fail do
+                Fr.SEARCH.ERROR(G,"RightCosets");
             od;
         fi;
         Info(InfoFR, 3, "RightCosets: searching at level ",G!.FRData.level);
@@ -2512,7 +2512,7 @@ InstallMethod(NormalClosure, "(FR) for two FR groups -- avoid using IsFinite",
         function(G,N)
     local g, gens, n, x;
 
-    SEARCH@.INIT(G);
+    Fr.SEARCH.INIT(G);
     gens := ShallowCopy(GeneratorsOfGroup(N));
     for n in gens do
         for g in G!.FRData.sphere[2] do
@@ -2560,15 +2560,15 @@ InstallMethod(NaturalHomomorphismByNormalSubgroupOp, "(FR) for a FR group and a 
         [IsFRGroup,IsFRGroup],
         function(G,N)
     local d, f;
-    SEARCH@.INIT(G);
+    Fr.SEARCH.INIT(G);
     d := Index(G,N);
     repeat
         f := G!.FRData.pi*NaturalHomomorphismByNormalSubgroupNC(Image(G!.FRData.pi),Image(G!.FRData.pi,N));
         if Size(Image(f))=d then
             return f;
         else
-            while SEARCH@.EXTEND(G,SEARCH@.QUOTIENT)=fail do
-                SEARCH@.ERROR(G,"NaturalHomomorphismByNormalSubgroupOp");
+            while Fr.SEARCH.EXTEND(G,Fr.SEARCH.QUOTIENT)=fail do
+                Fr.SEARCH.ERROR(G,"NaturalHomomorphismByNormalSubgroupOp");
             od;
         fi;
         Info(InfoFR, 2, "NaturalHomomorphismByNormalSubgroupOp: extending to level ",G!.FRData.level);
@@ -2742,10 +2742,10 @@ InstallMethod(FindBranchingSubgroup, "(FR) for an FR group, a level and a radius
         oldK := K;
         H := Stabilizer(K,AlphabetOfFRSemigroup(G),OnTuples);
         K := TrivialSubgroup(G);
-        SEARCH@.INIT(H);
+        Fr.SEARCH.INIT(H);
         for i in [2..radius] do
-            while not IsBound(H!.FRData.sphere[i]) and SEARCH@.EXTEND(H,SEARCH@.BALL)=fail do
-                SEARCH@.ERROR(G,"FindBranchingSubgroup");
+            while not IsBound(H!.FRData.sphere[i]) and Fr.SEARCH.EXTEND(H,Fr.SEARCH.BALL)=fail do
+                Fr.SEARCH.ERROR(G,"FindBranchingSubgroup");
             od;
             for g in H!.FRData.sphere[i] do
                 d := DecompositionOfFRElement(g);
@@ -2769,7 +2769,7 @@ end);
 InstallMethod(BranchStructure, [IsFRGroup and HasFullSCData],
         function(G)
     local X, Q;
-    
+
     X := AlphabetOfFRSemigroup(G);
     Q := TopVertexTransformations(G);
     return rec(group := TrivialSubgroup(Q),
@@ -2783,9 +2783,9 @@ end);
 InstallMethod(BranchStructure, [IsFRGroup],
         function(G)
     local pi, K, Q, W, S, SS, g, d, set, i;
-    
+
     K := BranchingSubgroup(G);
-    
+
     # a shortcut in case it's difficult to compute coset actions
     if false and HasHasCongruenceProperty(G) and HasCongruenceProperty(G) then
         d := 1;
@@ -2819,7 +2819,7 @@ end);
 
 #############################################################################
 
-BindGlobal("ASSIGNGENERATORVARIABLES@", function(gens)
+Fr.ASSIGNGENERATORVARIABLES := ( function(gens)
     local names, i;
     if ForAny(gens,g->HasName(g) or not IsMealyElement(g)) then
         names := [];
@@ -2852,19 +2852,19 @@ end);
 InstallMethod(AssignGeneratorVariables, "(FR) for an FR group",
         [IsFRGroup],
         function(G)
-    ASSIGNGENERATORVARIABLES@(GeneratorsOfGroup(G));
+    Fr.ASSIGNGENERATORVARIABLES(GeneratorsOfGroup(G));
 end);
 
 InstallMethod(AssignGeneratorVariables, "(FR) for an FR monoid",
         [IsFRMonoid],
         function(G)
-    ASSIGNGENERATORVARIABLES@(GeneratorsOfMonoid(G));
+    Fr.ASSIGNGENERATORVARIABLES(GeneratorsOfMonoid(G));
 end);
 
 InstallMethod(AssignGeneratorVariables, "(FR) for an FR semigroup",
         [IsFRSemigroup],
         function(G)
-    ASSIGNGENERATORVARIABLES@(GeneratorsOfSemigroup(G));
+    Fr.ASSIGNGENERATORVARIABLES(GeneratorsOfSemigroup(G));
 end);
 #############################################################################
 
@@ -2910,7 +2910,7 @@ InstallMethod(GermData, "(FR) for a FR group",
     # they are not generators of isotropy groups.
 
     for g in NucleusOfFRSemigroup(G) do
-        g := ASINTREP@(g);
+        g := Fr.ASINTREP(g);
         Add(data.nucleus,g);
         h := Germs(g);
         map := [];
@@ -3069,7 +3069,7 @@ InstallMethod(GermValue, "(FR) for a Mealy element and germ data",
         fi;
     end;
 
-    elm := ASINTREP@(elm);
+    elm := Fr.ASINTREP(elm);
     m := UnderlyingFRMachine(elm);
     m0 := m+data.nucleusmachine;
     corr := [ListTransformation(Correspondence(m0)[1],Size(StateSet(m))),
@@ -3098,13 +3098,13 @@ InstallMethod(GermValue, "(FR) for an FR element and germ data",
     p := First(data.machines,x->IsIdenticalObj(x[1],m));
     if p=fail then
         p := List(GeneratorsOfFRMachine(m),
-                  w->GermValue(ASINTREP@(FRElement(m,w)),data));
+                  w->GermValue(Fr.ASINTREP(FRElement(m,w)),data));
         if fail in p then return fail; fi;
         Add(data.machines,[m,p]);
     else
         p := p[2];
     fi;
-    return MAPPEDWORD@(InitialState(elm),p,One(data.group));
+    return Fr.MAPPEDWORD(InitialState(elm),p,One(data.group));
 end);
 
 InstallMethod(EpimorphismGermGroup, "(FR) for a group",
@@ -3115,7 +3115,7 @@ InstallMethod(EpimorphismGermGroup, "(FR) for a group",
     return GroupHomomorphismByFunction(G,data.group,x->GermValue(x,data));
 end);
 
-BindGlobal("HOMOMORPHISMGERMPERMGROUP@", function(G,data,n)
+Fr.HOMOMORPHISMGERMPERMGROUP := ( function(G,data,n)
     local l, e0, e1, Q;
 
     l := Length(AlphabetOfFRSemigroup(G))^n;
@@ -3130,13 +3130,13 @@ BindGlobal("HOMOMORPHISMGERMPERMGROUP@", function(G,data,n)
     end);
 end);
 
-BindGlobal("HOMOMORPHISMGERMPCGROUP@", function(G,data,n)
+Fr.HOMOMORPHISMGERMPCGROUP := ( function(G,data,n)
     local pcpP, pcpG, Q, pcpQ, l, i;
 
     l := Length(AlphabetOfFRSemigroup(G))^n;
     i := IsomorphismPcGroup(PermGroup(G,n));
     if i=fail then
-        return HOMOMORPHISMGERMPERMGROUP@(G,data,n);
+        return Fr.HOMOMORPHISMGERMPERMGROUP(G,data,n);
     fi;
     Q := WreathProduct(data.group,Range(i),InverseGeneralMapping(i),l);
     pcpP := Pcgs(Range(i));
@@ -3148,7 +3148,7 @@ BindGlobal("HOMOMORPHISMGERMPCGROUP@", function(G,data,n)
         x := PermList(d[2]);
         if not x in Source(i) then return fail; fi;
         e := ExponentsOfPcElement(pcpP,x^i);
-        for x in INVERSE@(d[2]) do
+        for x in Fr.INVERSE(d[2]) do
             y := GermValue(d[1][x],data);
             if y=fail then return fail; fi;
             Append(e,ExponentsOfPcElement(pcpG,y));
@@ -3157,13 +3157,13 @@ BindGlobal("HOMOMORPHISMGERMPCGROUP@", function(G,data,n)
     end);
 end);
 
-BindGlobal("HOMOMORPHISMGERMPCPGROUP@", function(G,data,n)
+Fr.HOMOMORPHISMGERMPCPGROUP := ( function(G,data,n)
     local pcpP, pcpG, Q, pcpQ, l, i;
 
     l := Length(AlphabetOfFRSemigroup(G))^n;
     i := IsomorphismPcpGroup(PermGroup(G,n));
     if i=fail then
-        return HOMOMORPHISMGERMPERMGROUP@(G,data,n);
+        return Fr.HOMOMORPHISMGERMPERMGROUP(G,data,n);
     fi;
     Q := WreathProduct(data.group,Range(i),InverseGeneralMapping(i),l);
     pcpP := Pcp(Range(i));
@@ -3175,7 +3175,7 @@ BindGlobal("HOMOMORPHISMGERMPCPGROUP@", function(G,data,n)
         x := PermList(d[2]);
         if not x in Source(i) then return fail; fi;
         e := ExponentsByPcp(pcpP,x^i);
-        for x in INVERSE@(d[2]) do
+        for x in Fr.INVERSE(d[2]) do
             y := GermValue(d[1][x],data);
             if y=fail then return fail; fi;
             Append(e,ExponentsByPcp(pcpG,y));
@@ -3184,7 +3184,7 @@ BindGlobal("HOMOMORPHISMGERMPCPGROUP@", function(G,data,n)
     end);
 end);
 
-BindGlobal("DIRECTPRODUCT@", function( list )
+Fr.DIRECTPRODUCT := ( function( list )
     local len, D, F, G, pcgsG, gensF, s, h, i, j, t,
           info, first, coll, orders, exp;
 
@@ -3253,9 +3253,9 @@ InstallMethod(EpimorphismGermGroup, "(FR) for a group and a level",
     data := GermData(G);
     emb := [GroupHomomorphismByFunction(G,data.group,x->GermValue(x,data))];
     if IsPcGroup(data.group) then
-        Append(emb,List([1..n],i->HOMOMORPHISMGERMPCGROUP@(G,data,i)));
+        Append(emb,List([1..n],i->Fr.HOMOMORPHISMGERMPCGROUP(G,data,i)));
     else
-        Append(emb,List([1..n],i->HOMOMORPHISMGERMPCPGROUP@(G,data,i)));
+        Append(emb,List([1..n],i->Fr.HOMOMORPHISMGERMPCPGROUP(G,data,i)));
     fi;
     if n=0 then
         pi := emb[1];
@@ -3265,7 +3265,7 @@ InstallMethod(EpimorphismGermGroup, "(FR) for a group and a level",
             pi := emb[n+1];
         else
             # P := DirectProduct(List(emb,Image));
-            P := DIRECTPRODUCT@(List(emb,Image));
+            P := Fr.DIRECTPRODUCT(List(emb,Image));
             emb := List([1..n+1],i->emb[i]*Embedding(P,i));
             pi := GroupHomomorphismByFunction(G,P,x->Product(emb,i->x^i));
         fi;
@@ -3345,7 +3345,7 @@ InstallMethod(IsomorphismFRGroup, "(FR) for a self-similar group with preimage d
         function(G)
     local r, gens;
 
-    gens := ISOMORPHICFRGENS@(GeneratorsOfGroup(G),AsGroupFRElement)[2];
+    gens := Fr.ISOMORPHICFRGENS(GeneratorsOfGroup(G),AsGroupFRElement)[2];
     r := FRGroupPreImageData(G)(0);
     return GroupHomomorphismByFunction(G,Group(gens),
                    g->FRElement(gens[1],UnderlyingElement(r.image(g))),

--- a/gap/helpers.gd
+++ b/gap/helpers.gd
@@ -141,7 +141,7 @@ DeclareProperty("IsProjectiveRepresentation", IsMapping);
 DeclareProperty("IsLinearRepresentation", IsProjectiveRepresentation);
 InstallTrueMethod(IsProjectiveRepresentation, IsLinearRepresentation);
 
-DeclareAttribute("IrreducibleRepresentations@", IsGroup);
+DeclareAttribute("Fr_IrreducibleRepresentations", IsGroup);
 
 DeclareOperation("ProjectiveRepresentationByFunction", [IsDomain,IsDomain,IsFunction]);
 DeclareOperation("LinearRepresentationByImages", [IsDomain,IsDomain,IsList,IsList]);
@@ -155,7 +155,7 @@ DeclareOperation("ProjectiveQuotient", [IsProjectiveRepresentation,IsGroupHomomo
 DeclareAttribute("CoboundaryMatrix", IsGroup);
 DeclareOperation("AreCohomologous", [IsList,IsList,IsGroup]);
 
-DeclareAttribute("EpimorphismSchurCover@", IsGroup);
+DeclareAttribute("Fr_EpimorphismSchurCover", IsGroup);
 
 #############################################################################
 

--- a/gap/helpers.gi
+++ b/gap/helpers.gi
@@ -11,7 +11,7 @@
 ##
 #############################################################################
 
-BindGlobal("INSTALLPRINTERS@", function(filter)
+Fr.INSTALLPRINTERS := ( function(filter)
     InstallMethod(PrintObj, "(FR)", [filter], 2*SUM_FLAGS, function(x) Print(String(x)); end);
     InstallMethod(ViewObj, "(FR)", [filter], 2*SUM_FLAGS, function(x) Print(ViewString(x)); end);
     InstallMethod(Display, "(FR)", [filter], 2*SUM_FLAGS, function(x) Print(DisplayString(x)); end);
@@ -48,24 +48,24 @@ end);
 ##
 #H WordGrowth(g,options)
 ##
-COLOURLIST@ :=
+Fr.COLOURLIST :=
   ["red","blue","green","gray","yellow","cyan","orange","purple"];
-BindGlobal("COLOURS@", function(i)
-    return COLOURLIST@[(i-1) mod Length(COLOURLIST@)+1];
+Fr.COLOURS := ( function(i)
+    return Fr.COLOURLIST[(i-1) mod Length(Fr.COLOURLIST)+1];
 end);
 
-BindGlobal("EXEC@", rec());
+Fr.EXEC := ( rec());
 # If 1 argument is passed, search path to find appropriate executable.
 # If >1 arguments, the first is a generic name, such as "psviewer", and the
 #     other arguments are possibilities to be searched in sequence, in the
 #     form ["progname","arg1",...,"argn"]. If the last argument is true, then
 #     do not raise an error if nothing was found.
-BindGlobal("CHECKEXEC@", function(arg)
+Fr.CHECKEXEC := ( function(arg)
     local a, prog, command;
     prog := arg[1];
-    
-    if IsBound(EXEC@.(prog)) then return; fi;
-    
+
+    if IsBound(Fr.EXEC.(prog)) then return; fi;
+
     if Length(arg)=1 then
         command := IO_FindExecutable(prog);
     else
@@ -78,21 +78,21 @@ BindGlobal("CHECKEXEC@", function(arg)
             fi;
         od;
     fi;
-    
+
     while command=fail do
-        Error("Could not find program \"",prog,"\" -- make sure it is installed, and/or set manually EXEC@FR.",prog);
+        Error("Could not find program \"",prog,"\" -- make sure it is installed, and/or set manually Fr.EXECFR.",prog);
     od;
-    EXEC@.(prog) := command;
+    Fr.EXEC.(prog) := command;
 end);
 
-BindGlobal("OUTPUTTEXTSTRING@", function(s)
+Fr.OUTPUTTEXTSTRING := ( function(s)
     local f;
     f := OutputTextString(s,false);
     SetPrintFormattingStatus(f,false);
     return f;
 end);
 
-BindGlobal("STRINGGROUP@",
+Fr.STRINGGROUP := (
         function(O)
     local s, os;
     s := "";
@@ -102,51 +102,51 @@ BindGlobal("STRINGGROUP@",
     return s;
 end);
 
-BindGlobal("EXECINSHELL@", function(input,command,detach)
+Fr.EXECINSHELL := ( function(input,command,detach)
     local tmp, outs, output;
     outs := "";
-    output := OUTPUTTEXTSTRING@(outs);
-    CHECKEXEC@("sh");
+    output := Fr.OUTPUTTEXTSTRING(outs);
+    Fr.CHECKEXEC("sh");
 
     if detach=fail then
         if IsString(input) then input := InputTextString(input); fi;
     else
 	tmp := Filename(DirectoryTemporary(), "stdin");
- 
+
         if not IsString(input) then
 	    input := ReadAll(input);
         fi;
         WriteAll(OutputTextFile(tmp,false), input);
         input := InputTextNone();
-        CHECKEXEC@("cat");
+        Fr.CHECKEXEC("cat");
         command := Concatenation("cat ",tmp,"|",command,"&");
     fi;
-    Process(DirectoryCurrent(), EXEC@.sh, input, output, ["-c", command]);
+    Process(DirectoryCurrent(), Fr.EXEC.sh, input, output, ["-c", command]);
     return outs;
 end);
 
-BindGlobal("DOT2DISPLAY@", function(str,prog)
+Fr.DOT2DISPLAY := ( function(str,prog)
     local command;
-    
-    CHECKEXEC@(prog);
-    CHECKEXEC@("psviewer",["display","-flatten","-"],["gv","-"],true);
-    if ValueOption("usesvg")<>fail or EXEC@.psviewer=fail then
-        CHECKEXEC@("svgviewer",["svg-view","--stdin"]);
-        command := Concatenation(EXEC@.(prog)," -Tsvg 2>/dev/null | ",EXEC@.svgviewer);
+
+    Fr.CHECKEXEC(prog);
+    Fr.CHECKEXEC("psviewer",["display","-flatten","-"],["gv","-"],true);
+    if ValueOption("usesvg")<>fail or Fr.EXEC.psviewer=fail then
+        Fr.CHECKEXEC("svgviewer",["svg-view","--stdin"]);
+        command := Concatenation(Fr.EXEC.(prog)," -Tsvg 2>/dev/null | ",Fr.EXEC.svgviewer);
     else
-        command := Concatenation(EXEC@.(prog)," -Gbgcolor=white -Tps 2>/dev/null | ",EXEC@.psviewer);
+        command := Concatenation(Fr.EXEC.(prog)," -Gbgcolor=white -Tps 2>/dev/null | ",Fr.EXEC.psviewer);
     fi;
-    return EXECINSHELL@(str,command,ValueOption("detach"));
+    return Fr.EXECINSHELL(str,command,ValueOption("detach"));
 end);
 
-BindGlobal("APPEND@", function(arg)
+Fr.APPEND := ( function(arg)
     local i;
     for i in [2..Length(arg)] do
         Append(arg[1],String(arg[i]));
     od;
 end);
 
-BindGlobal("CONCAT@", function(arg)
+Fr.CONCAT := ( function(arg)
     local i, s;
     s := "";
     for i in arg do
@@ -160,7 +160,7 @@ InstallGlobalFunction(WordGrowth, function(arg)
           tile, point, draw, S, plotedge, plotvertex,
           trackgroup, trackgens, track, trackhom,
           group, options, optionnames;
-    
+
     optionnames := ["track","limit","draw","point","ball","sphere","balls",
                     "spheres","spheresizes","ballsizes","act","tile"];
     if Length(arg)=2 then
@@ -177,7 +177,7 @@ InstallGlobalFunction(WordGrowth, function(arg)
             fi;
         od;
     fi;
-    
+
     if IsInt(options) then
         options := rec(spheresizes := options);
     fi;
@@ -298,10 +298,10 @@ InstallGlobalFunction(WordGrowth, function(arg)
             else
                 col := Position(gens,gen);
             fi;
-            APPEND@(S,"  ",nsrc,".",src," -> ",ndst,".",dst," [color=",COLOURS@(col),",dir=",dir,"];\n");
+            Fr.APPEND(S,"  ",nsrc,".",src," -> ",ndst,".",dst," [color=",Fr.COLOURS(col),",dir=",dir,"];\n");
         end;
         plotvertex := function(nsrc,src)
-            APPEND@(S,"  ",nsrc,".",src," [height=0.3,width=0.6,fixedsize=true]\n");
+            Fr.APPEND(S,"  ",nsrc,".",src," [height=0.3,width=0.6,fixedsize=true]\n");
         end;
     fi;
 
@@ -487,7 +487,7 @@ InstallGlobalFunction(WordGrowth, function(arg)
             if IsBoundGlobal("JupyterRenderable") then
                 return ValueGlobal("JupyterRenderable")(rec(("image/svg+xml") :=IO_PipeThrough("dot",["-Tsvg"],S)),rec());
             else
-                DOT2DISPLAY@(S, "neato");
+                Fr.DOT2DISPLAY(S, "neato");
             fi;
         fi;
     else
@@ -549,29 +549,29 @@ end);
 ##
 #H Draw order relations
 ##
-BindGlobal("ORDER2DOT@", function(R)
+Fr.ORDER2DOT := ( function(R)
     local i, j, succ, S;
-    
+
     if not IsBinaryRelationOnPointsRep(R) then
         R := AsBinaryRelationOnPoints(R);
     fi;
 
     S := "digraph ";
     if HasName(R) and ForAll(Name(R),IsAlphaChar) then
-        APPEND@(S, "\"",Name(R),"\"");
+        Fr.APPEND(S, "\"",Name(R),"\"");
     else
         Append(S,"HasseDiagram");
     fi;
     Append(S," {\n");
     for i in [1..DegreeOfBinaryRelation(R)] do
-        APPEND@(S,i," [shape=circle]\n");
+        Fr.APPEND(S,i," [shape=circle]\n");
     od;
-    
+
     succ := Successors(R);
 
     for i in [1..DegreeOfBinaryRelation(R)] do
         for j in succ[i] do
-            APPEND@(S,"  ",i," -> ",j," [label=\".\"];\n");
+            Fr.APPEND(S,"  ",i," -> ",j," [label=\".\"];\n");
         od;
     od;
     Append(S,"}\n");
@@ -581,13 +581,13 @@ end);
 InstallMethod(Draw, "(FR) for a binary relation",
         [IsBinaryRelation],
         function(R)
-    DOT2DISPLAY@(ORDER2DOT@(R),"dot");
+    Fr.DOT2DISPLAY(Fr.ORDER2DOT(R),"dot");
 end);
 
 InstallMethod(Draw, "(FR) for a binary relation and a filename",
         [IsBinaryRelation,IsString],
         function(R,S)
-    AppendTo(S,ORDER2DOT@(R));
+    AppendTo(S,Fr.ORDER2DOT(R));
 end);
 
 InstallMethod(HeightOfPoset, "(FR) for a binary relation",
@@ -709,7 +709,7 @@ InstallGlobalFunction(CoefficientsInAbelianExtension, function(x,seq,G)
                    s->Product([1..Length(seq)],n->seq[n]^s[n])/x in G);
 end);
 
-BindGlobal("MAPPEDWORD@", function(arg)
+Fr.MAPPEDWORD := ( function(arg)
     local i, e, w, gens;
 
     w := arg[1];
@@ -751,7 +751,7 @@ InstallGlobalFunction(MagmaHomomorphismByImagesNC, function(f,g,im)
         else
             one := fail;
         fi;
-        return MagmaHomomorphismByFunctionNC(f,g,w->MAPPEDWORD@(w,im,one));
+        return MagmaHomomorphismByFunctionNC(f,g,w->Fr.MAPPEDWORD(w,im,one));
     fi;
 
     if IsMonoid(f) and IsMonoid(g) then
@@ -759,14 +759,14 @@ InstallGlobalFunction(MagmaHomomorphismByImagesNC, function(f,g,im)
             local s;
             s := ShortMonoidWordInSet(f,x,infinity);
             if Length(s)<2 then return fail; fi;
-            return MAPPEDWORD@(s[2],im,One(g));
+            return Fr.MAPPEDWORD(s[2],im,One(g));
         end);
     else
         return MagmaHomomorphismByFunctionNC(f,g,function(x)
             local s;
             s := ShortSemigroupWordInSet(f,x,infinity);
             if Length(s)<2 then return fail; fi;
-            return MAPPEDWORD@(s[2],im,fail);
+            return Fr.MAPPEDWORD(s[2],im,fail);
         end);
     fi;
 end);
@@ -798,7 +798,7 @@ end);
 ##
 #H ShortMonoidRelations
 ##
-BindGlobal("FINDMONOIDRELATIONS@", function(gens,n)
+Fr.FINDMONOIDRELATIONS := ( function(gens,n)
     local free, seen, reducible, i, iterate, result, freegens;
     free := FreeMonoid(Length(gens));
     freegens := GeneratorsOfMonoid(free);
@@ -830,13 +830,13 @@ end);
 InstallMethod(ShortMonoidRelations, "for a monoid and a length",
         [IsMonoid,IsInt],
         function(m,n)
-    return FINDMONOIDRELATIONS@(GeneratorsOfMonoid(m),n);
+    return Fr.FINDMONOIDRELATIONS(GeneratorsOfMonoid(m),n);
 end);
 InstallMethod(ShortMonoidRelations, "for a list and a length",
         [IsListOrCollection,IsInt],
-        FINDMONOIDRELATIONS@);
+        Fr.FINDMONOIDRELATIONS);
 
-BindGlobal("FINDGROUPRELATIONS_ADD@", function(result,w)
+Fr.FINDGROUPRELATIONS_ADD := ( function(result,w)
     if Sum(ExponentSums(w))>=0 then
         Add(result,w);
     else
@@ -844,7 +844,7 @@ BindGlobal("FINDGROUPRELATIONS_ADD@", function(result,w)
     fi;
 end);
 
-BindGlobal("FINDGROUPRELATIONS@", function(group,gens,n)
+Fr.FINDGROUPRELATIONS := ( function(group,gens,n)
     local freegens, pigens, freegensinv, pi, inv,
           i, j, k, m, mm, newf, newg, result, rws, seen, todo, x, y, z;
 
@@ -855,9 +855,9 @@ BindGlobal("FINDGROUPRELATIONS@", function(group,gens,n)
     for i in [1..Length(y)] do
         for j in [i+1..Length(y)] do
             if y[i]=y[j] then
-                FINDGROUPRELATIONS_ADD@(result,z[i]/z[j]);
+                Fr.FINDGROUPRELATIONS_ADD(result,z[i]/z[j]);
             elif y[i]=y[j]^-1 then
-                FINDGROUPRELATIONS_ADD@(result,z[i]*z[j]);
+                Fr.FINDGROUPRELATIONS_ADD(result,z[i]*z[j]);
             fi;
         od;
     od;
@@ -872,7 +872,7 @@ BindGlobal("FINDGROUPRELATIONS@", function(group,gens,n)
         Add(freegensinv,freegens[j]);
         AddRuleReduced(rws,[[i,j],[]]);
         if j=i then
-            FINDGROUPRELATIONS_ADD@(result,(freegens[i]^pi)^2);
+            Fr.FINDGROUPRELATIONS_ADD(result,(freegens[i]^pi)^2);
         fi;
     od;
     freegensinv := List([1..Length(freegens)],
@@ -895,7 +895,7 @@ BindGlobal("FINDGROUPRELATIONS@", function(group,gens,n)
                 mm := Length(x);
                 newf := ReducedForm(rws,newf*x^inv);
                 if Length(newf)<m+mm then continue; fi;
-                FINDGROUPRELATIONS_ADD@(result,newf^pi);
+                Fr.FINDGROUPRELATIONS_ADD(result,newf^pi);
                 x := [newf^2,(newf^inv)^2];
                 for j in [1..2] do
                     if m=mm then
@@ -924,15 +924,15 @@ end);
 InstallMethod(ShortGroupRelations, "for a group and a length",
         [IsGroup,IsInt],
         function(g,n)
-    return FINDGROUPRELATIONS@(g,GeneratorsOfGroup(g),n);
+    return Fr.FINDGROUPRELATIONS(g,GeneratorsOfGroup(g),n);
 end);
 InstallMethod(ShortGroupRelations, "for a list and a length",
         [IsListOrCollection,IsInt],
         function(g,n)
-    return FINDGROUPRELATIONS@(Group(g),g,n);
+    return Fr.FINDGROUPRELATIONS(Group(g),g,n);
 end);
 
-BindGlobal("SHORTWORDINSET@", function(f,fgen,fone,ggen,gone,set,result,n)
+Fr.SHORTWORDINSET := ( function(f,fgen,fone,ggen,gone,set,result,n)
     local x, newfx, newlen, i, seen, forbidden, todo, justone, compare;
     if n<0 then
         n := -n;
@@ -944,7 +944,7 @@ BindGlobal("SHORTWORDINSET@", function(f,fgen,fone,ggen,gone,set,result,n)
         if IsFunction(set) then
             return set(elm);
         elif FamilyObj(elm)=FamilyObj(set) and elm=set then
-            return true;    
+            return true;
         elif IsListOrCollection(set) then
             return elm in set;
         fi;
@@ -991,7 +991,7 @@ InstallMethod(ShortGroupWordInSet, "(FR) for a group, an object and an int",
     s := GeneratorsOfGroup(g);
     f := FreeGroup(Length(s));
     sinv := Concatenation(List(s,x->[x^-1,x]));
-    return SHORTWORDINSET@(f,GeneratorsOfMonoid(f),One(f),sinv,One(g),
+    return Fr.SHORTWORDINSET(f,GeneratorsOfMonoid(f),One(f),sinv,One(g),
             set,[GroupHomomorphismByImagesNC(f,g,GeneratorsOfGroup(f),s)],n);
 end);
 
@@ -1001,7 +1001,7 @@ InstallMethod(ShortMonoidWordInSet, "(FR) for a monoid, an object and an int",
     local f, s;
     s := GeneratorsOfMonoid(g);
     f := FreeMonoid(Length(s));
-    return SHORTWORDINSET@(f,GeneratorsOfMonoid(f),One(f),s,One(g),
+    return Fr.SHORTWORDINSET(f,GeneratorsOfMonoid(f),One(f),s,One(g),
             set,[FreeMonoidNatHomByGeneratorsNC(f,g)],n);
 end);
 
@@ -1012,7 +1012,7 @@ InstallMethod(ShortSemigroupWordInSet, "(FR) for a semigroup, an object and an i
     s := GeneratorsOfSemigroup(g);
     f := FreeSemigroup(Length(s));
     #!!! bug: GAP refuses free semigroups on 0 generators
-    return SHORTWORDINSET@(f,GeneratorsOfSemigroup(f),fail,s,fail,
+    return Fr.SHORTWORDINSET(f,GeneratorsOfSemigroup(f),fail,s,fail,
             set,[FreeSemigroupNatHomByGeneratorsNC(f,g)],n);
 end);
 #############################################################################
@@ -1023,11 +1023,11 @@ end);
 ##
 InstallGlobalFunction(SurfaceBraidFpGroup, function(n,g,p)
   local G, R, a, b, z, s;
-  a := List([1..g],i->CONCAT@("a",i));
-  b := List([1..g],i->CONCAT@("b",i));
-  s := List([1..n-1],i->CONCAT@("s",i));
+  a := List([1..g],i->Fr.CONCAT("a",i));
+  b := List([1..g],i->Fr.CONCAT("b",i));
+  s := List([1..n-1],i->Fr.CONCAT("s",i));
   if p>0 then
-    z := List([1..p-1],i->CONCAT@("z",i));
+    z := List([1..p-1],i->Fr.CONCAT("z",i));
   else
     z := [];
   fi;
@@ -1093,12 +1093,12 @@ InstallGlobalFunction(ArtinRepresentation, function(n)
                                    S{[i+2..n]}))));
 end);
 
-BindGlobal("ENDOISONE@", function(x)
+Fr.ENDOISONE := ( function(x)
     return ForAll(GeneratorsOfGroup(Source(x)),s->s=s^x);
 end);
 
-BindGlobal("ENDONORM@", function(x)
-    if ENDOISONE@(x) then
+Fr.ENDONORM := ( function(x)
+    if Fr.ENDOISONE(x) then
         return 0;
     else
         return LogInt(Maximum(List(GeneratorsOfGroup(Source(x)),s->Length(s^x)))^4,2);
@@ -1170,7 +1170,7 @@ InstallMethod(ProductBOIIdeal, "for two ideals over ring with invertible basis",
     return c;
 end);
 
-BindGlobal("DIMENSIONSERIES@", function(A,n)
+Fr.DIMENSIONSERIES := ( function(A,n)
     local L, k, i;
     L := [AsTwoSidedIdeal(A,A)];
     i := AugmentationIdeal(A);
@@ -1185,11 +1185,11 @@ end);
 
 InstallMethod(DimensionSeries, "for an algebra with one",
         [IsAlgebra and HasAugmentationIdeal],
-        A->DIMENSIONSERIES@(A,infinity));
+        A->Fr.DIMENSIONSERIES(A,infinity));
 
 InstallMethod(DimensionSeries, "for an algebra with one and a limit",
         [IsAlgebra and HasAugmentationIdeal,IsInt],
-        DIMENSIONSERIES@);
+        Fr.DIMENSIONSERIES);
 #############################################################################
 
 #############################################################################
@@ -1340,31 +1340,31 @@ end);
 #############################################################################
 # Dirichlet series
 #############################################################################
-BindGlobal("NEWDIRICHLETSERIES@", function(arg)
+Fr.NEWDIRICHLETSERIES := ( function(arg)
     return Objectify(NewType(DS_FAMILY,IsDirichletSeries),arg);
 end);
 
 InstallMethod(DirichletSeries, [], function()
-    return NEWDIRICHLETSERIES@([],[],infinity);
+    return Fr.NEWDIRICHLETSERIES([],[],infinity);
 end);
 
 InstallMethod(DirichletSeries, [IsInt], function(n)
-    return NEWDIRICHLETSERIES@([],[],n);
+    return Fr.NEWDIRICHLETSERIES([],[],n);
 end);
 
 InstallMethod(DirichletSeries, [IsList,IsList], function(ind,coeff)
-    return NEWDIRICHLETSERIES@(ind,coeff,Maximum(ind));
+    return Fr.NEWDIRICHLETSERIES(ind,coeff,Maximum(ind));
 end);
 
 InstallMethod(DirichletSeries, [IsList,IsList,IsInt], function(ind,coeff,n)
-    return NEWDIRICHLETSERIES@(ind,coeff,n);
+    return Fr.NEWDIRICHLETSERIES(ind,coeff,n);
 end);
-      
+
 InstallMethod(DirichletSeries, [IsDirichletSeries,IsInt],
         function(s,n)
     local p;
     p := First([1..Length(s![1])+1],i->not IsBound(s![1][i]) or s![1][i] > n);
-    return NEWDIRICHLETSERIES@(s![1]{[1..p-1]},s![2]{[1..p-1]},n);
+    return Fr.NEWDIRICHLETSERIES(s![1]{[1..p-1]},s![2]{[1..p-1]},n);
 end);
 
 InstallMethod(ShrunkDirichletSeries, [IsDirichletSeries],
@@ -1372,7 +1372,7 @@ InstallMethod(ShrunkDirichletSeries, [IsDirichletSeries],
     local p, n;
     n := DegreeOfDirichletSeries(s);
     p := First([1..Length(s![1])+1],i->not IsBound(s![1][i]) or s![1][i] > n);
-    return NEWDIRICHLETSERIES@(s![1]{[1..p-1]},s![2]{[1..p-1]},n);
+    return Fr.NEWDIRICHLETSERIES(s![1]{[1..p-1]},s![2]{[1..p-1]},n);
 end);
 
 InstallMethod(String,[IsDirichletSeries],
@@ -1412,12 +1412,12 @@ end);
 InstallMethod(\+, [IsDirichletSeries,IsDirichletSeries],
         function(s1,s2)
     local i, p, maxdeg, coeff, val;
-    
+
     maxdeg := Maximum(s1![3],s2![3]);
-    
+
     coeff := ShallowCopy(s1![1]);
     val := ShallowCopy(s1![2]);
-    
+
     for i in [1..Length(s2![1])] do
         p := PositionSorted(coeff,s2![1][i]);
         if p>Length(coeff) or coeff[p]<>s2![1][i] then
@@ -1426,43 +1426,43 @@ InstallMethod(\+, [IsDirichletSeries,IsDirichletSeries],
         fi;
         val[p] := val[p] + s2![2][i];
     od;
-    return NEWDIRICHLETSERIES@(coeff,val,maxdeg);
+    return Fr.NEWDIRICHLETSERIES(coeff,val,maxdeg);
 end);
 
 InstallMethod(AdditiveInverseSameMutability, [IsDirichletSeries],
         function(s)
-    return NEWDIRICHLETSERIES@(s![1],-s![2],s![3]);
+    return Fr.NEWDIRICHLETSERIES(s![1],-s![2],s![3]);
 end);
 
 InstallMethod(Zero, [IsDirichletSeries],
         function(s)
-    return NEWDIRICHLETSERIES@([],[],s![3]);
+    return Fr.NEWDIRICHLETSERIES([],[],s![3]);
 end);
 
 InstallMethod(OneMutable, [IsDirichletSeries],
         function(s)
-    return NEWDIRICHLETSERIES@([1],[1],s![3]);
+    return Fr.NEWDIRICHLETSERIES([1],[1],s![3]);
 end);
 
 InstallMethod(\*, [IsDirichletSeries,IsScalar],
         function(s,x)
-    return NEWDIRICHLETSERIES@(s![1],s![2]*x,s![3]);
+    return Fr.NEWDIRICHLETSERIES(s![1],s![2]*x,s![3]);
 end);
 
 InstallMethod(\*, [IsScalar,IsDirichletSeries],
         function(x,s)
-    return NEWDIRICHLETSERIES@(s![1],x*s![2],s![3]);
+    return Fr.NEWDIRICHLETSERIES(s![1],x*s![2],s![3]);
 end);
 
 InstallMethod(\*, [IsDirichletSeries,IsDirichletSeries],
         function(s1,s2)
     local coeff, val, i, j, degree, p, maxdeg;
-    
+
     maxdeg := Maximum(s1![3],s2![3]);
 
     coeff := [];
     val := [];
- 
+
     for i in [1..Length(s1![1])] do
         for j in [1..Length(s2![1])] do
             degree := s1![1][i]*s2![1][j];
@@ -1475,7 +1475,7 @@ InstallMethod(\*, [IsDirichletSeries,IsDirichletSeries],
             val[p] := val[p] + s1![2][i]*s2![2][j];
         od;
     od;
-    return NEWDIRICHLETSERIES@(coeff,val,maxdeg);
+    return Fr.NEWDIRICHLETSERIES(coeff,val,maxdeg);
 end);
 
 InstallMethod(\=, [IsDirichletSeries,IsDirichletSeries],
@@ -1528,14 +1528,14 @@ InstallMethod(SpreadDirichletSeries, [IsDirichletSeries, IsInt],
         function(s,n)
     local p;
     p := First([1..Length(s![1])+1],i->not IsBound(s![1][i]) or s![1][i]^n > s![3]);
-    return NEWDIRICHLETSERIES@(List(s![1]{[1..p-1]},i->i^n),s![2]{[1..p-1]},s![3]);
+    return Fr.NEWDIRICHLETSERIES(List(s![1]{[1..p-1]},i->i^n),s![2]{[1..p-1]},s![3]);
 end);
 
 InstallMethod(ShiftDirichletSeries, [IsDirichletSeries,IsInt],
         function(s,n)
     local p;
     p := First([1..Length(s![1])+1],i->not IsBound(s![1][i]) or s![1][i]*n > s![3]);
-    return NEWDIRICHLETSERIES@(n*s![1]{[1..p-1]},s![2]{[1..p-1]},s![3]);
+    return Fr.NEWDIRICHLETSERIES(n*s![1]{[1..p-1]},s![2]{[1..p-1]},s![3]);
 end);
 
 InstallMethod(ZetaSeriesOfGroup, [IsGroup],
@@ -1563,29 +1563,29 @@ InstallOtherMethod(Value, [IsDirichletSeries,IsRingElement],
 ##
 #F JenningsLieAlgebra
 ##
-BindGlobal("LIEELEMENT@", function(A,l)
+Fr.LIEELEMENT := ( function(A,l)
     return Objectify(A!.type,[A,l]);
 end);
 
-LIEEXTENDLCS@ := fail; # shut up warning
+Fr.LIEEXTENDLCS := fail; # shut up warning
 
-BindGlobal("LIECOMPUTEBASIS@", function(A,d)
+Fr.LIECOMPUTEBASIS := ( function(A,d)
     local i, l;
 
     if IsBound(A!.basis[d]) then return; fi;
 
-    LIEEXTENDLCS@(A,d);
+    Fr.LIEEXTENDLCS(A,d);
     A!.hom[d] := NaturalHomomorphismByNormalSubgroup(A!.lcs[d],A!.lcs[d+1]);
     A!.basis[d] := [];
     for i in IdentityMat(Length(AbelianInvariants(Range(A!.hom[d]))),A!.ring) do
         l := []; l[d] := i;
-        Add(A!.basis[d],LIEELEMENT@(A,l));
+        Add(A!.basis[d],Fr.LIEELEMENT(A,l));
     od;
     A!.transversal[d] := List(A!.pcp(Range(A!.hom[d])),
                               x->PreImagesRepresentativeNC(A!.hom[d],x));
 end);
 
-BindGlobal("JENNINGSSERIES@", function(G,p,d)
+Fr.JENNINGSSERIES := ( function(G,p,d)
     local n, L, C, T;
 
     L := [G];
@@ -1605,8 +1605,7 @@ end);
 if not IsBound(PqEpimorphism) then PqEpimorphism := ReturnFail; fi;
 if not IsBound(NqEpimorphismNilpotentQuotient) then NqEpimorphismNilpotentQuotient := ReturnFail; fi;
 
-UnbindGlobal("LIEEXTENDLCS@");
-BindGlobal("LIEEXTENDLCS@", function(A,d)
+Fr.LIEEXTENDLCS := ( function(A,d)
     local i;
 
     if d<=A!.degree then return; fi;
@@ -1620,11 +1619,11 @@ BindGlobal("LIEEXTENDLCS@", function(A,d)
         A!.pcp := Pcgs;
         A!.exp := ExponentsOfPcElement;
     fi;
-    A!.lcs := JENNINGSSERIES@(Range(A!.quo),Characteristic(A!.ring),d+1);
+    A!.lcs := Fr.JENNINGSSERIES(Range(A!.quo),Characteristic(A!.ring),d+1);
     A!.degree := d;
     for i in BoundPositions(A!.basis) do
         Unbind(A!.basis[i]);
-        LIECOMPUTEBASIS@(A,i);
+        Fr.LIECOMPUTEBASIS(A,i);
     od;
 end);
 
@@ -1651,7 +1650,7 @@ InstallOtherMethod(JenningsLieAlgebra, "(FR) for a ring and an FP group",
                      basis := []));
     A!.type := NewType(A!.family,IsLieObject and IsLieFpElementRep);
     Grading(A);
-    SetRepresentative(A,LIEELEMENT@(A,[]));
+    SetRepresentative(A,Fr.LIEELEMENT(A,[]));
     SetLeftActingDomain(A,R);
     SetZero(C,Representative(A));
     return A;
@@ -1660,15 +1659,15 @@ end);
 InstallMethod(GeneratorsOfAlgebra, "(FR) for an FP Lie algebra",
         [IsFpLieAlgebra],
         function(A)
-    LIECOMPUTEBASIS@(A,1);
-    return List(GeneratorsOfGroup(A!.group),x->LIEELEMENT@(A,[One(A!.ring)*A!.exp(A!.pcp(Range(A!.hom[1])),(x^A!.quo)^A!.hom[1])]));
+    Fr.LIECOMPUTEBASIS(A,1);
+    return List(GeneratorsOfGroup(A!.group),x->Fr.LIEELEMENT(A,[One(A!.ring)*A!.exp(A!.pcp(Range(A!.hom[1])),(x^A!.quo)^A!.hom[1])]));
 end);
 
 InstallMethod(Grading, "(FR) for a FP Lie algebra",
         [IsFpLieAlgebra],
         function(A)
     return rec(min_degree := 1, source := Integers, hom_components := function(d)
-        LIECOMPUTEBASIS@(A,d);
+        Fr.LIECOMPUTEBASIS(A,d);
         return VectorSpace(A!.ring,A!.basis[d],Representative(A));
     end);
 end);
@@ -1684,12 +1683,12 @@ InstallMethod(ViewString, "(FR) for a FP Lie algebra",
         else
             Append(s,", computed up to");
         fi;
-        APPEND@(s," degree ",A!.degree);
+        Fr.APPEND(s," degree ",A!.degree);
     fi;
     Append(s,">");
     return s;
 end);
-INSTALLPRINTERS@(IsFpLieAlgebra);
+Fr.INSTALLPRINTERS(IsFpLieAlgebra);
 
 InstallOtherMethod(ZeroOp, "(FR) for a FP Lie algebra",
         [IsFpLieAlgebra],
@@ -1700,7 +1699,7 @@ end);
 InstallMethod(ZeroOp, "(FR) for a FP Lie algebra element",
         [IsLieObject and IsLieFpElementRep],
         function(X)
-    return LIEELEMENT@(X![1],[]);
+    return Fr.LIEELEMENT(X![1],[]);
 end);
 
 InstallMethod(EQ, "(FR) for FP Lie algebra elements",
@@ -1756,7 +1755,7 @@ InstallMethod(\+, "(FR) for FP Lie algebra elements",
             m[n] := X![2][n]+Y![2][n];
         fi;
     od;
-    return LIEELEMENT@(X![1],m);
+    return Fr.LIEELEMENT(X![1],m);
 end);
 
 InstallMethod(\-, "(FR) for FP Lie algebra elements",
@@ -1774,7 +1773,7 @@ InstallMethod(\-, "(FR) for FP Lie algebra elements",
             m[n] := X![2][n]-Y![2][n];
         fi;
     od;
-    return LIEELEMENT@(X![1],m);
+    return Fr.LIEELEMENT(X![1],m);
 end);
 
 InstallMethod(AdditiveInverseSameMutability, "(FR) for an FP Lie algebra element",
@@ -1785,7 +1784,7 @@ InstallMethod(AdditiveInverseSameMutability, "(FR) for an FP Lie algebra element
     for n in BoundPositions(X![2]) do
         m[n] := -X![2][n];
     od;
-    return LIEELEMENT@(X![1],m);
+    return Fr.LIEELEMENT(X![1],m);
 end);
 
 InstallMethod(\*, "(FR) for FP Lie algebra elements",
@@ -1799,7 +1798,7 @@ InstallMethod(\*, "(FR) for FP Lie algebra elements",
         if not IsBound(A!.bracket[i]) then A!.bracket[i] := []; fi;
         for j in BoundPositions(Y![2]) do
             if not IsBound(A!.bracket[i][j]) then A!.bracket[i][j] := []; fi;
-            LIECOMPUTEBASIS@(A,i+j);
+            Fr.LIECOMPUTEBASIS(A,i+j);
             if not IsBound(m[i+j]) then
                 m[i+j] := List(A!.basis[i+j],i->Zero(A!.ring));
             fi;
@@ -1819,26 +1818,26 @@ InstallMethod(\*, "(FR) for FP Lie algebra elements",
     for i in BoundPositions(m) do
         if ForAll(m[i],IsZero) then Unbind(m[i]); fi;
     od;
-    return LIEELEMENT@(X![1],m);
+    return Fr.LIEELEMENT(X![1],m);
 end);
 
 InstallMethod(\*, "(FR) for a scalar and an FP Lie algebra element",
         [IsScalar,IsLieObject and IsLieFpElementRep],
         function(X,Y)
-    return LIEELEMENT@(Y![1],X*Y![2]);
+    return Fr.LIEELEMENT(Y![1],X*Y![2]);
 end);
 
 InstallMethod(\*, "(FR) for an FP Lie algebra element and a scalar",
         [IsLieObject and IsLieFpElementRep,IsScalar],
         function(X,Y)
-    return LIEELEMENT@(X![1],X![2]*Y);
+    return Fr.LIEELEMENT(X![1],X![2]*Y);
 end);
 
-BindGlobal("PTHPOWER@", function(X,A,p,s)
+Fr.PTHPOWER := ( function(X,A,p,s)
     local m, i, ii, j, t;
     m := [];
     for i in BoundPositions(X![2]) do
-        LIECOMPUTEBASIS@(A,p*i);
+        Fr.LIECOMPUTEBASIS(A,p*i);
         if not IsBound(m[p*i]) then
             m[p*i] := List(A!.basis[p*i],i->Zero(A!.ring));
         fi;
@@ -1850,7 +1849,7 @@ BindGlobal("PTHPOWER@", function(X,A,p,s)
             m[p*i] := m[p*i] + X![2][i][ii]^p*A!.pmap[i][ii];
         od;
     od;
-    m := LIEELEMENT@(X![1],m);
+    m := Fr.LIEELEMENT(X![1],m);
     for i in BoundPositions(X![2]) do
         for ii in [1..Length(A!.basis[i])] do
             if IsBound(X![2][i]) and not IsZero(X![2][i][ii]) then
@@ -1872,7 +1871,7 @@ InstallMethod(\^, "(FR) for an FR Lie algebra element and a p-power",
         Error(Y," must be a power of the characteristic");
     fi;
     for n in [1..LogInt(Y,p)] do
-        X := PTHPOWER@(X,X![1],p,PowerS(X![1]));
+        X := Fr.PTHPOWER(X,X![1],p,PowerS(X![1]));
     od;
     return X;
 end);
@@ -1899,14 +1898,14 @@ InstallMethod(ViewString, "(FR) for a FP Lie algebra element",
         if ForAll([n+1..Length(X![2])],i->not IsBound(X![2][i]) or ForAll(X![2][i],IsZero)) then
             Append(s,"homogeneous ");
         fi;
-        APPEND@(s,"degree-",n);
+        Fr.APPEND(s,"degree-",n);
     fi;
     Append(s," Lie element>");
     return s;
 end);
-INSTALLPRINTERS@(IsLieObject and IsLieFpElementRep);
+Fr.INSTALLPRINTERS(IsLieObject and IsLieFpElementRep);
 
-BindGlobal("LIE2VECTOR@", function(dims,dim,x)
+Fr.LIE2VECTOR := ( function(dims,dim,x)
     local i, v;
     v := List([1..dim],i->Zero(x![1]!.ring));
     for i in BoundPositions(x![2]) do
@@ -1947,16 +1946,16 @@ end,
         dims[i] := [dim+1..dim+Length(R!.basis[i])];
         dim := dim+Length(R!.basis[i]);
     od;
-    b := List(b,x->LIE2VECTOR@(dims,dim,x));
+    b := List(b,x->Fr.LIE2VECTOR(dims,dim,x));
     return rec(dims := dims,
                dim := dim,
                ring := R,
-               space := VectorSpace(LeftActingDomain(V),b,LIE2VECTOR@(dims,dim,Zero(V))));
+               space := VectorSpace(LeftActingDomain(V),b,Fr.LIE2VECTOR(dims,dim,Zero(V))));
 end,
   NiceVector := function(V,v)
     local info, x;
     info := NiceFreeLeftModuleInfo(V);
-    x := LIE2VECTOR@(info.dims,info.dim,v);
+    x := Fr.LIE2VECTOR(info.dims,info.dim,v);
     if x=fail or not x in info.space then
         return fail;
     else
@@ -1971,7 +1970,7 @@ end,
     for i in BoundPositions(info.dims) do
         l[i] := v{info.dims[i]};
     od;
-    return LIEELEMENT@(info.ring,l);
+    return Fr.LIEELEMENT(info.ring,l);
 end));
 #############################################################################
 
@@ -1981,10 +1980,10 @@ end));
 InstallMethod(SolutionMatModN, [IsMatrix,IsVector,IsPosInt],
         function(mat,vec,N)
     local sol, i, p, s0, M, row;
-    
+
     sol := List(mat,row->0);
     if N=1 then return sol; fi; # bug with FactorsInt containing 1
-    
+
     mat := SmithNormalFormIntegerMatTransforms(mat);
     vec := vec*mat.coltrans;
     row := mat.rowtrans;
@@ -2006,11 +2005,11 @@ InstallMethod(SolutionMatModN, [IsMatrix,IsVector,IsPosInt],
         sol := sol + M*s0;
         M := M*p;
     od;
-    
+
     return sol*row;
 end);
 
-BindGlobal("FRAC@", function(x)
+Fr.FRAC := ( function(x)
     x := x-Int(x);
     if x>=0 then return x; else return x+1; fi;
 end);
@@ -2022,7 +2021,7 @@ end);
 InstallMethod(SolutionMatMod1, [IsMatrix, IsVector],
         function(mat,vec)
     local sol, N, d, i, snf, row;
-    
+
     # non-optimal: should store the Smith normal form as an attribute
     snf := SmithNormalFormIntegerMatTransforms(mat);
     vec := vec*snf.coltrans;
@@ -2036,10 +2035,10 @@ InstallMethod(SolutionMatMod1, [IsMatrix, IsVector],
         else
             d := 0;
         fi;
-        
+
         if d=0 then
-            if FRAC@(vec[i])<>0 then return fail; fi; # no solution
-            
+            if Fr.FRAC(vec[i])<>0 then return fail; fi; # no solution
+
             if i<=Length(snf.normal) then
                 Add(sol,[0]); # infinite set of solutions, this is one
             fi;
@@ -2047,7 +2046,7 @@ InstallMethod(SolutionMatMod1, [IsMatrix, IsVector],
             Add(sol,(vec[i]+[0..d-1])/d);
         fi;
     od;
-    return Set(Cartesian(sol)*row,x->List(x,FRAC@));
+    return Set(Cartesian(sol)*row,x->List(x,Fr.FRAC));
 end);
 
 # argument of a cyclotomic number, assumed to be a multiple of a root of unity.
@@ -2068,7 +2067,7 @@ InstallMethod(ArgumentOfCyclotomic, [IsCyc], function(z)
 end);
 
 ################################################################
-InstallMethod(IrreducibleRepresentations@, [IsGroup], function(G)
+InstallMethod(Fr_IrreducibleRepresentations, [IsGroup], function(G)
     local reps, r;
     reps := IrreducibleRepresentations(G);
     for r in reps do SetIsLinearRepresentation(r,true); od;
@@ -2095,7 +2094,7 @@ InstallMethod(DegreeOfProjectiveRepresentation, [IsProjectiveRepresentation],
         function(rep)
     return Length(Image(rep,One(Source(rep))));
 end);
-        
+
 InstallMethod(Degree, [IsProjectiveRepresentation],
         DegreeOfProjectiveRepresentation);
 
@@ -2105,17 +2104,17 @@ InstallMethod(Degree, [IsProjectiveRepresentation],
 InstallMethod(ProjectiveExtension, [IsLinearRepresentation, IsGroup],
         function(rep, group)
     local n, rank, transversal, mat, res, t, g, P, m, a, b;
-     
+
     n := Source(rep);
-    
+
     if n=group then # special cases, which GAP doesn't handle well
         return rep;
     elif IsTrivial(n) then
         return LinearRepresentationByImages(group,Range(rep),GeneratorsOfGroup(group),List(GeneratorsOfGroup(group),x->One(Range(rep))));
     fi;
-    
+
     rank := Length(Image(rep,One(n)));
- 
+
     res := [];
     transversal := List(RightTransversal(group,n),x->CanonicalRightCosetElement(n,x));
     for t in transversal do
@@ -2143,7 +2142,7 @@ InstallMethod(ProjectiveExtension, [IsLinearRepresentation, IsGroup],
         t := CanonicalRightCosetElement(n,x);
         return Image(rep,x/t)*res[Position(transversal,t)];
     end);
-end);    
+end);
 
 InstallMethod(ProjectiveExtension, [IsProjectiveRepresentation, IsGroup],
         function(rep, group)
@@ -2151,7 +2150,7 @@ InstallMethod(ProjectiveExtension, [IsProjectiveRepresentation, IsGroup],
     if Source(rep)=group then
         return rep;
     fi;
-    
+
     # don't bother
     TryNextMethod();
 end);
@@ -2161,10 +2160,10 @@ InstallMethod(ProjectiveQuotient, [IsProjectiveRepresentation,IsGroupHomomorphis
     return ProjectiveRepresentationByFunction(Image(epi),Range(rep),
                    x->CanonicalRightCosetElement(Kernel(epi),PreImagesRepresentativeNC(epi,x))^rep);
 end);
-        
+
 InstallMethod(CoboundaryMatrix, [IsGroup], function(G)
     local mat, i, j, k, m, elements;
-    
+
     elements := AsSortedList(G);
     mat := [];
     for i in [1..Length(elements)] do
@@ -2180,9 +2179,9 @@ InstallMethod(CoboundaryMatrix, [IsGroup], function(G)
     return mat;
 end);
 
-InstallMethod(EpimorphismSchurCover@, [IsGroup], EpimorphismSchurCover);
+InstallMethod(Fr_EpimorphismSchurCover, [IsGroup], EpimorphismSchurCover);
 
-InstallMethod(EpimorphismSchurCover@, [IsPcGroup],
+InstallMethod(Fr_EpimorphismSchurCover, [IsPcGroup],
         function(G)
     local c;
     c := EpimorphismSchurCover(G);
@@ -2191,7 +2190,7 @@ InstallMethod(EpimorphismSchurCover@, [IsPcGroup],
     return c;
 end);
 
-InstallMethod(EpimorphismSchurCover@, [IsPermGroup],
+InstallMethod(Fr_EpimorphismSchurCover, [IsPermGroup],
         function(G)
     local c;
     c := EpimorphismSchurCover(G);
@@ -2201,7 +2200,7 @@ end);
 InstallMethod(TensorProductOp, [IsLinearRepresentation,IsLinearRepresentation],
         function(r1,r2)
     local range, g, gens, img;
-    
+
     g := Source(r1);
     gens := GeneratorsOfGroup(g);
     img := List(gens,x->KroneckerProduct(x^r1,x^r2));
@@ -2212,10 +2211,10 @@ end);
 InstallMethod(TensorProductOp, [IsProjectiveRepresentation,IsProjectiveRepresentation],
         function(r1,r2)
     local range, g, img;
-    
+
     g := Source(r1);
     img := List(AsSortedList(g),x->KroneckerProduct(x^r1,x^r2));
-    
+
     return ProjectiveRepresentationByFunction(g,Group(img),x->KroneckerProduct(x^r1,x^r2));
 end);
 
@@ -2223,9 +2222,9 @@ end);
 InstallMethod(AreCohomologous, [IsList,IsList,IsGroup],
         function(c1,c2,Q)
     local elements, diff, i, j, k, m, denom;
-    
+
     if c1=c2 then return true; fi; # speedup
-    
+
     return SolutionMatMod1(CoboundaryMatrix(Q),c1-c2)<>fail;
 end);
 

--- a/gap/linear-gbnp.gi
+++ b/gap/linear-gbnp.gi
@@ -38,7 +38,7 @@ InstallMethod(FRMachineRWS, "(FR) for an algebra machine",
     return rws;
 end);
 
-BindGlobal("ALGEBRAISZERO@", function(M,x)
+Fr.ALGEBRAISZERO := ( function(M,x)
     local rws, todo, i;
 
     rws := NewFRMachineRWS(M);
@@ -46,9 +46,9 @@ BindGlobal("ALGEBRAISZERO@", function(M,x)
     for x in todo do
         x := rws.reduce(x);
         if not IsZero(x) then
-            if not IsZero(SUBS@(x,M!.output)) then return false; fi;
+            if not IsZero(Fr.SUBS(x,M!.output)) then return false; fi;
             rws.addrule(x);
-            x := SUBS@(x,M!.transitions);
+            x := Fr.SUBS(x,M!.transitions);
             for i in x do Append(todo,i); od;
         fi;
     od;

--- a/gap/linear.gi
+++ b/gap/linear.gi
@@ -15,7 +15,7 @@
 # apply a ring homomorphism to expr. here im is the list of images of
 # generators of a free algebra; expr is an element of the free algebra.
 # the last two entries in im are 0 and 1.
-BindGlobal("SUBS@", function(expr,im)
+Fr.SUBS := ( function(expr,im)
     local mapped, i, j, m, e, w, one;
 
     e := ExtRepOfObj(expr);
@@ -43,7 +43,7 @@ BindGlobal("SUBS@", function(expr,im)
     return mapped;
 end);
 
-BindGlobal("AUGMENTATION@", function(expr)
+Fr.AUGMENTATION := ( function(expr)
     local e;
 
     e := ExtRepOfObj(expr);
@@ -54,7 +54,7 @@ BindGlobal("AUGMENTATION@", function(expr)
     fi;
 end);
 
-BindGlobal("ALGEBRAELEMENT@", function(f,M,s)
+Fr.ALGEBRAELEMENT := ( function(f,M,s)
     return Objectify(NewType(f,IsLinearFRElement and IsFRElementStdRep),
                    [M,s]);
 end);
@@ -72,41 +72,41 @@ InstallMethod(InitialState, "(FR) for a linear machine",
 InstallMethod(Output, "(FR) for a linear machine",
         [IsLinearFRMachine and IsAlgebraFRMachineRep,IsElementOfFreeMagmaRing],
         function(M,s)
-    return SUBS@(s,M!.output);
+    return Fr.SUBS(s,M!.output);
 end);
 
 InstallMethod(Output, "(FR) for a linear element",
         [IsLinearFRElement and IsFRElementStdRep],
-        E->SUBS@(E![2],E![1]!.output));
+        E->Fr.SUBS(E![2],E![1]!.output));
 
 InstallMethod(Transitions, "(FR) for a linear machine",
         [IsLinearFRMachine and IsAlgebraFRMachineRep,IsElementOfFreeMagmaRing,IsVector],
         function(M,s,a)
-    return a*SUBS@(s,M!.transitions);
+    return a*Fr.SUBS(s,M!.transitions);
 end);
 
 InstallMethod(Transition, "(FR) for a linear machine",
         [IsLinearFRMachine and IsAlgebraFRMachineRep,IsElementOfFreeMagmaRing,IsVector,IsVector],
         function(M,s,a,b)
-    return a*SUBS@(s,M!.transitions)*b;
+    return a*Fr.SUBS(s,M!.transitions)*b;
 end);
 
 InstallMethod(Transitions, "(FR) for a linear element",
         [IsLinearFRElement and IsFRElementStdRep,IsVector],
         function(E,a)
-    return a*SUBS@(E![2],E![1]!.transitions);
+    return a*Fr.SUBS(E![2],E![1]!.transitions);
 end);
 
 InstallOtherMethod(\[\], "(FR) for a linear element",
         [IsLinearFRElement and IsFRElementStdRep,IsPosInt],
         function(E,i)
-    return List(SUBS@(E![2],E![1]!.transitions)[i],v->ALGEBRAELEMENT@(FamilyObj(E),E![1],v));
+    return List(Fr.SUBS(E![2],E![1]!.transitions)[i],v->Fr.ALGEBRAELEMENT(FamilyObj(E),E![1],v));
 end);
 
 InstallMethod(Transition, "(FR) for a linear element",
         [IsLinearFRElement and IsFRElementStdRep,IsVector,IsVector],
         function(E,a,b)
-    return a*SUBS@(E![2],E![1]!.transitions)*b;
+    return a*Fr.SUBS(E![2],E![1]!.transitions)*b;
 end);
 
 InstallMethod(StateSet, "(FR) for a linear machine in vector rep",
@@ -124,7 +124,7 @@ InstallMethod(GeneratorsOfFRMachine, "(FR) for a linear machine",
 InstallOtherMethod(\^, "(FR) for a vector and a linear element",
         [IsVector, IsLinearFRElement and IsFRElementStdRep],
         function(v,E)
-    return v*MATRIX@(SUBS@(E![1],E![2]!.transitions),v->SUBS@(v,E![1]!.output));
+    return v*Fr.MATRIX(Fr.SUBS(E![1],E![2]!.transitions),v->Fr.SUBS(v,E![1]!.output));
 end);
 
 InstallMethod(Activity, "(FR) for a linear machine and a level",
@@ -138,7 +138,7 @@ InstallMethod(Activity, "(FR) for a linear machine and a level",
         for x in oldm do
             mm := List(E![1]!.transitions[1],i->[]);
             for x in x do
-                e := SUBS@(x,E![1]!.transitions);
+                e := Fr.SUBS(x,E![1]!.transitions);
                 for i in [1..Length(e)] do
                     Append(mm[i],e[i]);
                 od;
@@ -146,7 +146,7 @@ InstallMethod(Activity, "(FR) for a linear machine and a level",
             Append(m,mm);
         od;
     od;
-    m := MATRIX@(m,v->SUBS@(v,E![1]!.output));
+    m := Fr.MATRIX(m,v->Fr.SUBS(v,E![1]!.output));
     b := ValueOption("blocks");
     if b=fail then
         ConvertToMatrixRep(m);
@@ -164,7 +164,7 @@ InstallMethod(Activities, "(FR) for a linear machine and a level",
         function(E,n)
     local b, i, j, m, mm, oldm, e, x, result;
     m := [[E![2]]];
-    result := [[[SUBS@(E![2],E![1]!.output)]]];
+    result := [[[Fr.SUBS(E![2],E![1]!.output)]]];
     b := ValueOption("blocks");
     for j in [1..n] do
         oldm := m;
@@ -172,14 +172,14 @@ InstallMethod(Activities, "(FR) for a linear machine and a level",
         for x in oldm do
             mm := List(E![1]!.transitions[1],i->[]);
             for x in x do
-                e := SUBS@(x,E![1]!.transitions);
+                e := Fr.SUBS(x,E![1]!.transitions);
                 for i in [1..Length(e)] do
                     Append(mm[i],e[i]);
                 od;
             od;
             Append(m,mm);
         od;
-        x := MATRIX@(m,v->SUBS@(v,E![1]!.output));
+        x := Fr.MATRIX(m,v->Fr.SUBS(v,E![1]!.output));
         if b=fail then
             ConvertToMatrixRep(m);
         else
@@ -193,7 +193,7 @@ InstallMethod(Activities, "(FR) for a linear machine and a level",
     return result;
 end);
 
-BindGlobal("LINEARSTATES@", function(l)
+Fr.LINEARSTATES := ( function(l)
     local W, todo, x;
     todo := NewFIFO(l);
     W := VectorSpace(LeftActingDomain(l[1]),[],Zero(l[1]));
@@ -214,7 +214,7 @@ end);
 InstallOtherMethod(State, "(FR) for a linear element and two vectors",
         [IsLinearFRElement and IsFRElementStdRep, IsVector, IsVector],
         function(E,a,b)
-    return ALGEBRAELEMENT@(FamilyObj(E),E![1],a*SUBS@(E![2],E![1]!.transitions)*b);
+    return Fr.ALGEBRAELEMENT(FamilyObj(E),E![1],a*Fr.SUBS(E![2],E![1]!.transitions)*b);
 end);
 
 InstallOtherMethod(NestedMatrixState, "(FR) for a linear element and two lists",
@@ -223,9 +223,9 @@ InstallOtherMethod(NestedMatrixState, "(FR) for a linear element and two lists",
     local x, n;
     x := E![2];
     for n in [1..Length(ilist)] do
-        x := SUBS@(x,E![1]!.transitions)[ilist[n]][jlist[n]];
+        x := Fr.SUBS(x,E![1]!.transitions)[ilist[n]][jlist[n]];
     od;
-    return ALGEBRAELEMENT@(FamilyObj(E),E![1],x);
+    return Fr.ALGEBRAELEMENT(FamilyObj(E),E![1],x);
 end);
 
 InstallOtherMethod(NestedMatrixCoefficient, "(FR) for a linear element and two lists",
@@ -234,25 +234,25 @@ InstallOtherMethod(NestedMatrixCoefficient, "(FR) for a linear element and two l
     local x, n;
     x := E![2];
     for n in [1..Length(ilist)] do
-        x := SUBS@(x,E![1]!.transitions)[ilist[n]][jlist[n]];
+        x := Fr.SUBS(x,E![1]!.transitions)[ilist[n]][jlist[n]];
     od;
-    return SUBS@(x,E![1]!.output);
+    return Fr.SUBS(x,E![1]!.output);
 end);
 
 InstallMethod(DecompositionOfFRElement, "(FR) for a linear element",
         [IsLinearFRElement and IsFRElementStdRep],
         function(E)
-    return MATRIX@(SUBS@(E![2],E![1]!.transitions),
-                   v->ALGEBRAELEMENT@(FamilyObj(E),E![1],v));
+    return Fr.MATRIX(Fr.SUBS(E![2],E![1]!.transitions),
+                   v->Fr.ALGEBRAELEMENT(FamilyObj(E),E![1],v));
 end);
 
 InstallMethod(States, "(FR) for a linear element",
         [IsLinearFRElement and IsFRElementStdRep],
-        E->LINEARSTATES@([E]));
+        E->Fr.LINEARSTATES([E]));
 
 InstallMethod(States, "(FR) for a space of linear elements",
         [IsVectorSpace and IsFRElementCollection],
-        V->LINEARSTATES@(GeneratorsOfVectorSpace(V)));
+        V->Fr.LINEARSTATES(GeneratorsOfVectorSpace(V)));
 
 InstallMethod(States, "(FR) for a collection of linear elements",
         [IsFRElementCollection],1, # give it higher priority than FR method
@@ -260,7 +260,7 @@ InstallMethod(States, "(FR) for a collection of linear elements",
     if not ForAll(L,IsLinearFRElement) then
         TryNextMethod();
     fi;
-    return LINEARSTATES@(L);
+    return Fr.LINEARSTATES(L);
 end);
 
 InstallMethod(TransposedFRElement, "(FR) for a linear element",
@@ -286,7 +286,7 @@ InstallMethod(AlgebraMachineNC, "(FR) for family, free, transitions, output",
     return M;
 end);
 
-BindGlobal("PREPARESUBS@", function(n,l)
+Fr.PREPARESUBS := ( function(n,l)
     if Length(l)<n then
         Error("Substitution list is too short -- should have at least ",n," elements\n");
     fi;
@@ -302,8 +302,8 @@ InstallMethod(AlgebraMachine, "(FR) for domain, free, transitions, output",
         function(r,free,transitions,output)
     local n;
     n := Length(GeneratorsOfAlgebraWithOne(free));
-    transitions := PREPARESUBS@(n,transitions);
-    output := PREPARESUBS@(n,output);
+    transitions := Fr.PREPARESUBS(n,transitions);
+    output := Fr.PREPARESUBS(n,output);
     return AlgebraMachineNC(FRMFamily(r^Length(transitions[1])),
                    free,transitions,output);
 end);
@@ -324,7 +324,7 @@ InstallMethod(AlgebraElementNC, "(FR) for family, free, transitions, output and 
         function(f,free,transitions,output,input)
     local M;
     M := AlgebraMachineNC(FRMFamily(f), free, transitions, output);
-    return ALGEBRAELEMENT@(f,M,input);
+    return Fr.ALGEBRAELEMENT(f,M,input);
 end);
 
 InstallMethod(AlgebraElement, "(FR) for domain, free, transitions, output and input",
@@ -333,7 +333,7 @@ InstallMethod(AlgebraElement, "(FR) for domain, free, transitions, output and in
         function(r,free,transitions,output,input)
     local M;
     M := AlgebraMachine(r, free, transitions, output);
-    return ALGEBRAELEMENT@(FREFamily(M),M,input);
+    return Fr.ALGEBRAELEMENT(FREFamily(M),M,input);
 end);
 
 InstallMethod(AlgebraElement, "(FR) for domain, free, transitions, output, input and category",
@@ -343,11 +343,11 @@ InstallMethod(AlgebraElement, "(FR) for domain, free, transitions, output, input
     local M, f;
     M := AlgebraMachine(r, free, transitions, output);
     if cat=IsJacobianElement then
-        f := FRJFAMILY@(M);
+        f := Fr.FRJFAMILY(M);
     else
         f := FREFamily(M);
     fi;
-    return ALGEBRAELEMENT@(f,M,input);
+    return Fr.ALGEBRAELEMENT(f,M,input);
 end);
 
 InstallMethod(AlgebraElement, "(FR) for free, transitions, output and input",
@@ -359,7 +359,7 @@ end);
 InstallMethod(FRElement, "(FR) for a linear machine and a state",
         [IsLinearFRMachine and IsAlgebraFRMachineRep,IsElementOfFreeMagmaRing],
         function(M,s)
-    return ALGEBRAELEMENT@(FREFamily(M),M,s);
+    return Fr.ALGEBRAELEMENT(FREFamily(M),M,s);
 end);
 
 InstallMethod(FRElement, "(FR) for a linear machine, a state and a category",
@@ -367,38 +367,38 @@ InstallMethod(FRElement, "(FR) for a linear machine, a state and a category",
         function(M,s,cat)
     local f;
     if cat=IsJacobianElement then
-        f := FRJFAMILY@(M);
+        f := Fr.FRJFAMILY(M);
     else
         f := FREFamily(M);
     fi;
-    return ALGEBRAELEMENT@(f,M,s);
+    return Fr.ALGEBRAELEMENT(f,M,s);
 end);
 
 InstallMethod(FRElement, "(FR) for a linear element and a state",
         [IsLinearFRElement and IsFRElementStdRep, IsElementOfFreeMagmaRing],
         function(E,s)
-    return ALGEBRAELEMENT@(FamilyObj(E),E![1],s);
+    return Fr.ALGEBRAELEMENT(FamilyObj(E),E![1],s);
 end);
 
 InstallMethod(FRElement, "(FR) for a linear machine and a state index",
         [IsLinearFRMachine and IsAlgebraFRMachineRep,IsInt],
         function(M,s)
-    return ALGEBRAELEMENT@(FREFamily(M),M,GeneratorsOfAlgebraWithOne(M!.free)[s]);
+    return Fr.ALGEBRAELEMENT(FREFamily(M),M,GeneratorsOfAlgebraWithOne(M!.free)[s]);
 end);
 
 InstallMethod(FRElement, "(FR) for a linear element and a state index",
         [IsLinearFRElement and IsFRElementStdRep, IsInt],
         function(E,s)
-    return ALGEBRAELEMENT@(FamilyObj(E),E![1],GeneratorsOfAlgebraWithOne(E![1]!.free)[s]);
+    return Fr.ALGEBRAELEMENT(FamilyObj(E),E![1],GeneratorsOfAlgebraWithOne(E![1]!.free)[s]);
 end);
 
 InstallMethod(LieObject, "(FR) for an associative linear element",
         [IsLinearFRElement and IsFRElementStdRep and IsAssociativeElement],
-        e->ALGEBRAELEMENT@(FRJFAMILY@(e),e![1],e![2]));
+        e->Fr.ALGEBRAELEMENT(Fr.FRJFAMILY(e),e![1],e![2]));
 
 InstallMethod(AssociativeObject, "(FR) for a jacobian linear element",
         [IsLinearFRElement and IsFRElementStdRep and IsJacobianElement],
-        e->ALGEBRAELEMENT@(FREFamily(e),e![1],e![2]));
+        e->Fr.ALGEBRAELEMENT(FREFamily(e),e![1],e![2]));
 #############################################################################
 
 #############################################################################
@@ -410,7 +410,7 @@ InstallMethod(AssociativeObject, "(FR) for a jacobian linear element",
 InstallMethod(ViewString, "(FR) for a linear machine",
         [IsLinearFRMachine and IsAlgebraFRMachineRep],
         function(M)
-    return CONCAT@("<Linear machine on alphabet ", LeftActingDomain(M), "^",
+    return Fr.CONCAT("<Linear machine on alphabet ", LeftActingDomain(M), "^",
           Length(M!.transitions[1]), " with generators ",
           GeneratorsOfAlgebraWithOne(M!.free), ">");
 end);
@@ -419,7 +419,7 @@ InstallMethod(ViewString, "(FR) for a linear element",
         [IsLinearFRElement and IsFRElementStdRep],
         function(E)
     local s;
-    s := CONCAT@("<", LeftActingDomain(E), "^", Length(E![1]!.transitions[1]), "|",
+    s := Fr.CONCAT("<", LeftActingDomain(E), "^", Length(E![1]!.transitions[1]), "|",
           E![2]);
     if IsJacobianElement(E) then Append(s,"-"); fi;
     Append(s,">");
@@ -429,7 +429,7 @@ end);
 InstallMethod(String, "(FR) Linear machine to string",
         [IsLinearFRMachine and IsAlgebraFRMachineRep],
         function(M)
-    return CONCAT@("AlgebraMachine(",LeftActingDomain(M),", ", M!.transitions,", ", M!.output,")");
+    return Fr.CONCAT("AlgebraMachine(",LeftActingDomain(M),", ", M!.transitions,", ", M!.output,")");
 end);
 
 InstallMethod(String, "(FR) Linear element to string",
@@ -441,13 +441,13 @@ InstallMethod(String, "(FR) Linear element to string",
     else
         x := "";
     fi;
-    return CONCAT@("AlgebraElement(",LeftActingDomain(E),", ",
+    return Fr.CONCAT("AlgebraElement(",LeftActingDomain(E),", ",
                    E![1]!.free,", ",
                    E![1]!.transitions,", ",
                    E![1]!.output,", ",E![2],x,")");
 end);
 
-BindGlobal("ALG2STRING@", function(expr)
+Fr.ALG2STRING := ( function(expr)
     local i, j, m, e, w, map, mapped, one;
 
     e := ExtRepOfObj(expr);
@@ -499,8 +499,8 @@ InstallMethod(DisplayString, "(FR) for a linear machine",
     r := LeftActingDomain(M);
     n := Length(M!.transitions[1]);
     m := Length(GeneratorsOfAlgebraWithOne(M!.free));
-    xlen := Maximum(List(Flat(M!.transitions),x->Length(ALG2STRING@(x))))+1;
-    xprint := x->String(ALG2STRING@(x),xlen-1);
+    xlen := Maximum(List(Flat(M!.transitions),x->Length(Fr.ALG2STRING(x))))+1;
+    xprint := x->String(Fr.ALG2STRING(x),xlen-1);
     xrule := ListWithIdenticalEntries(xlen,'-');
     headlen := Length(String(r))+1;
     headrule := ListWithIdenticalEntries(headlen,'-');
@@ -508,35 +508,35 @@ InstallMethod(DisplayString, "(FR) for a linear machine",
 
     s := Concatenation(String(r,headlen)," |");
     for i in [1..n] do
-        APPEND@(s,String(i,QuoInt(xlen,2)+1),String("",xlen-QuoInt(xlen,2)),"|");
+        Fr.APPEND(s,String(i,QuoInt(xlen,2)+1),String("",xlen-QuoInt(xlen,2)),"|");
     od;
-    APPEND@(s,"\n");
-    APPEND@(s,headrule, "-+");
-    for i in [1..n] do APPEND@(s,xrule,"-+"); od;
-    APPEND@(s,"\n");
+    Fr.APPEND(s,"\n");
+    Fr.APPEND(s,headrule, "-+");
+    for i in [1..n] do Fr.APPEND(s,xrule,"-+"); od;
+    Fr.APPEND(s,"\n");
     for i in [1..n] do
-        APPEND@(s,String(i,headlen)," |");
+        Fr.APPEND(s,String(i,headlen)," |");
         for j in [1..m] do
-            if j>1 then APPEND@(s,headblank," |"); fi;
+            if j>1 then Fr.APPEND(s,headblank," |"); fi;
             for k in [1..n] do
-                APPEND@(s," ",xprint(M!.transitions[j][i][k])," |");
+                Fr.APPEND(s," ",xprint(M!.transitions[j][i][k])," |");
             od;
-            APPEND@(s,"\n");
+            Fr.APPEND(s,"\n");
         od;
-        APPEND@(s,headrule,"-+");
-        for i in [1..n] do APPEND@(s,xrule,"-+"); od;
-        APPEND@(s,"\n");
+        Fr.APPEND(s,headrule,"-+");
+        for i in [1..n] do Fr.APPEND(s,xrule,"-+"); od;
+        Fr.APPEND(s,"\n");
     od;
-    APPEND@(s,"Output:");
+    Fr.APPEND(s,"Output:");
     for i in [1..m] do
-        APPEND@(s," ");
+        Fr.APPEND(s," ");
         if IsFFE(M!.output[i]) then
-            APPEND@(s,IntFFE(M!.output[i]));
+            Fr.APPEND(s,IntFFE(M!.output[i]));
         else
-            APPEND@(s,M!.output[i]);
+            Fr.APPEND(s,M!.output[i]);
         fi;
     od;
-    APPEND@(s,"\n");
+    Fr.APPEND(s,"\n");
     return s;
 end);
 
@@ -548,7 +548,7 @@ InstallMethod(DisplayString, "(FR) for a linear element",
     if IsJacobianElement(E) then
         Append(s, "Jacobian; ");
     fi;
-    APPEND@(s,"Initial state: ",ALG2STRING@(E![2]),"\n");
+    Fr.APPEND(s,"Initial state: ",Fr.ALG2STRING(E![2]),"\n");
     return s;
 end);
 #############################################################################
@@ -558,7 +558,7 @@ end);
 #M AsAlgebraMachine
 #M AsAlgebraElement
 ##
-BindGlobal("ASALGEBRAMACHINE@", function(r,M)
+Fr.ASALGEBRAMACHINE := ( function(r,M)
     local s, f, g, inj, A, trans, out, zero, i, x;
     g := GeneratorsOfFRMachine(M);
     f := FreeAssociativeAlgebraWithOne(r,ElementsFamily(FamilyObj(M!.free))!.names);
@@ -585,18 +585,18 @@ end);
 
 InstallMethod(AsAlgebraMachine, "(FR) for a semigroup FR machine",
         [IsRing,IsSemigroupFRMachine],
-        ASALGEBRAMACHINE@);
+        Fr.ASALGEBRAMACHINE);
 
 InstallMethod(AsAlgebraMachine, "(FR) for a monoid FR machine",
         [IsRing,IsMonoidFRMachine],
-        ASALGEBRAMACHINE@);
+        Fr.ASALGEBRAMACHINE);
 
 InstallMethod(AsAlgebraMachine, "(FR) for a group FR machine",
         [IsRing,IsGroupFRMachine],
         function(r,M)
     local N, A;
     N := AsMonoidFRMachine(M);
-    A := ASALGEBRAMACHINE@(r,N);
+    A := Fr.ASALGEBRAMACHINE(r,N);
     A!.Correspondence := Correspondence(N)*Correspondence(A);
     return A;
 end);
@@ -607,7 +607,7 @@ InstallMethod(AsAlgebraMachine, "(FR) for a Mealy machine",
     local N, A;
     Info(InfoFR,2,"AsAlgebraMachine: converting to monoid machine");
     N := AsMonoidFRMachine(M);
-    A := ASALGEBRAMACHINE@(r,N);
+    A := Fr.ASALGEBRAMACHINE(r,N);
     A!.Correspondence := List(Correspondence(N),x->x^Correspondence(A));
     return A;
 end);
@@ -616,13 +616,13 @@ InstallMethod(AsLinearMachine, "(FR) for an FR machine",
         [IsRing,IsFRMachine],
         AsAlgebraMachine);
 
-BindGlobal("VECTOR2ALGEBRA@", function(fam,M)
+Fr.VECTOR2ALGEBRA := ( function(fam,M)
     local i, f, g, N, trans, out;
     f := FreeAssociativeAlgebraWithOne(LeftActingDomain(M),Length(M!.output));
     g := GeneratorsOfAlgebraWithOne(f);
     trans := [];
     for i in [1..Length(g)] do
-        Add(trans,MATRIX@(M!.transitions,v->v[i]*g));
+        Add(trans,Fr.MATRIX(M!.transitions,v->v[i]*g));
     od;
     Add(trans,Zero(trans[1]));
     Add(trans,One(trans[1]));
@@ -636,7 +636,7 @@ end);
 
 InstallMethod(AsAlgebraMachine, "(FR) for a vector machine",
         [IsLinearFRMachine and IsVectorFRMachineRep],
-        M->VECTOR2ALGEBRA@(FamilyObj(M),M));
+        M->Fr.VECTOR2ALGEBRA(FamilyObj(M),M));
 
 InstallMethod(AsAlgebraMachine, "(FR) for an algebra machine",
         [IsLinearFRMachine],
@@ -648,7 +648,7 @@ InstallMethod(AsVectorMachine, "(FR) for an algebra machine",
     local gens, states, B, corr, d, trans, out, i, j, s, t;
 
     gens := List(GeneratorsOfFRMachine(M),x->FRElement(M,x));
-    states := LINEARSTATES@(gens);
+    states := Fr.LINEARSTATES(gens);
     B := Basis(states);
     d := List(B,DecompositionOfFRElement);
     trans := [];
@@ -669,26 +669,26 @@ InstallMethod(AsVectorMachine, "(FR) for a linear machine",
         [IsLinearFRMachine],
         X->X);
 
-BindGlobal("ASALGEBRAELEMENT@", function(r,E)
+Fr.ASALGEBRAELEMENT := ( function(r,E)
     local A;
-    A := ASALGEBRAMACHINE@(r,E![1]);
+    A := Fr.ASALGEBRAMACHINE(r,E![1]);
     return FRElement(A,E![2]^Correspondence(A));
 end);
 
 InstallMethod(AsAlgebraElement, "(FR) for a semigroup FR element",
         [IsRing,IsSemigroupFRElement],
-        ASALGEBRAELEMENT@);
+        Fr.ASALGEBRAELEMENT);
 
 InstallMethod(AsAlgebraElement, "(FR) for a monoid FR element",
         [IsRing,IsMonoidFRElement],
-        ASALGEBRAELEMENT@);
+        Fr.ASALGEBRAELEMENT);
 
 InstallMethod(AsAlgebraElement, "(FR) for a group FR element",
         [IsRing,IsGroupFRElement],
         function(r,E)
     local M, A;
     M := AsMonoidFRMachine(E![1]);
-    A := ASALGEBRAMACHINE@(r,M);
+    A := Fr.ASALGEBRAMACHINE(r,M);
     return FRElement(A,(E![2]^Correspondence(M))^Correspondence(A));
 end);
 
@@ -696,7 +696,7 @@ InstallMethod(AsAlgebraElement, "(FR) for a Mealy element",
         [IsRing,IsMealyElement and IsMealyMachineIntRep],
         function(r,E)
     Info(InfoFR,2,"AsAlgebraElement: converting to monoid element");
-    return ASALGEBRAELEMENT@(r,AsMonoidFRElement(E));
+    return Fr.ASALGEBRAELEMENT(r,AsMonoidFRElement(E));
 end);
 
 InstallMethod(AsLinearElement, "(FR) for an FR element",
@@ -707,7 +707,7 @@ InstallMethod(AsAlgebraElement, "(FR) for a vector element",
         [IsLinearFRElement and IsVectorFRMachineRep],
         function(E)
     local N;
-    N := VECTOR2ALGEBRA@(FRMFamily(E),E);
+    N := Fr.VECTOR2ALGEBRA(FRMFamily(E),E);
     return FRElement(N,Correspondence(N)[1]);
 end);
 
@@ -735,7 +735,7 @@ InstallMethod(AsVectorElement, "(FR) for an algebra element",
         od;
         Add(trans,row);
     od;
-    B := VECTORMINIMIZE@(FamilyObj(E),LeftActingDomain(E),
+    B := Fr.VECTORMINIMIZE(FamilyObj(E),LeftActingDomain(E),
                  trans,output,input,0,false);
     return B;
 end);
@@ -770,7 +770,7 @@ end);
 
 InstallMethod(OneOp, "(FR) for a linear element",
         [IsLinearFRElement and IsFRElementStdRep],
-        E->ALGEBRAELEMENT@(FamilyObj(E),E![1],One(E![2])));
+        E->Fr.ALGEBRAELEMENT(FamilyObj(E),E![1],One(E![2])));
 
 InstallMethod(ZeroOp, "(FR) for a linear machine",
         [IsLinearFRMachine and IsAlgebraFRMachineRep],
@@ -784,7 +784,7 @@ end);
 
 InstallMethod(ZeroOp, "(FR) for a linear element",
         [IsLinearFRElement and IsFRElementStdRep],
-        E->ALGEBRAELEMENT@(FamilyObj(E),E![1],Zero(E![2])));
+        E->Fr.ALGEBRAELEMENT(FamilyObj(E),E![1],Zero(E![2])));
 
 InstallMethod(\+, "for two linear machines", IsIdenticalObj,
         [IsLinearFRMachine and IsAlgebraFRMachineRep,
@@ -810,10 +810,10 @@ InstallMethod(\+, "for two linear machines", IsIdenticalObj,
     Add(y[2],Zero(x)); Add(y[2],One(x));
     trans := [];
     for i in [1..m] do
-        Add(trans,MATRIX@(M!.transitions[i],v->SUBS@(v,y[1])));
+        Add(trans,Fr.MATRIX(M!.transitions[i],v->Fr.SUBS(v,y[1])));
     od;
     for i in N!.transitions do
-        Add(trans,MATRIX@(i,v->SUBS@(v,y[2])));
+        Add(trans,Fr.MATRIX(i,v->Fr.SUBS(v,y[2])));
     od;
     x := AlgebraMachineNC(FamilyObj(M),x,
                  trans,Concatenation(M!.output{[1..m]},N!.output));
@@ -827,12 +827,12 @@ InstallMethod(\+, "for two linear elements", IsIdenticalObj,
         function(E,F)
     local M;
     if E![1]=F![1] then
-        return ALGEBRAELEMENT@(FamilyObj(E),E![1],E![2]+F![2]);
+        return Fr.ALGEBRAELEMENT(FamilyObj(E),E![1],E![2]+F![2]);
     else
         M := E![1]+F![1];
-        return ALGEBRAELEMENT@(FamilyObj(E),M,
-                       SUBS@(E![2],Correspondence(M)[1])+
-                       SUBS@(F![2],Correspondence(M)[2]));
+        return Fr.ALGEBRAELEMENT(FamilyObj(E),M,
+                       Fr.SUBS(E![2],Correspondence(M)[1])+
+                       Fr.SUBS(F![2],Correspondence(M)[2]));
     fi;
 end);
 
@@ -840,14 +840,14 @@ InstallMethod(\+, "for a scalar and a linear element",
         [IsScalar,IsLinearFRElement and IsFRElementStdRep],
         function(x,E)
     if not IsRat(x) and not x in LeftActingDomain(E) then TryNextMethod(); fi; # matrix?
-    return ALGEBRAELEMENT@(FamilyObj(E),E![1],x*One(E![1]!.free)+E![2]);
+    return Fr.ALGEBRAELEMENT(FamilyObj(E),E![1],x*One(E![1]!.free)+E![2]);
 end);
 
 InstallMethod(\+, "for a linear element and a scalar",
         [IsLinearFRElement and IsFRElementStdRep,IsScalar],
         function(E,x)
     if not IsRat(x) and not x in LeftActingDomain(E) then TryNextMethod(); fi; # matrix?
-    return ALGEBRAELEMENT@(FamilyObj(E),E![1],E![2]+x*One(E![1]!.free));
+    return Fr.ALGEBRAELEMENT(FamilyObj(E),E![1],E![2]+x*One(E![1]!.free));
 end);
 
 InstallMethod(\+, "(FR) for two linear elements", IsIdenticalObj,
@@ -875,7 +875,7 @@ end);
 InstallMethod(AdditiveInverseSameMutability, "for a linear element",
         [IsLinearFRElement and IsFRElementStdRep],
         function(E)
-    return ALGEBRAELEMENT@(FamilyObj(E),E![1],-E![2]);
+    return Fr.ALGEBRAELEMENT(FamilyObj(E),E![1],-E![2]);
 end);
 
 InstallMethod(\*, "for two linear machines", IsIdenticalObj,
@@ -891,12 +891,12 @@ InstallMethod(\*, "for two linear elements", IsIdenticalObj,
         function(E,F)
     local M;
     if E![1]=F![1] then
-        return ALGEBRAELEMENT@(FamilyObj(E),E![1],E![2]*F![2]);
+        return Fr.ALGEBRAELEMENT(FamilyObj(E),E![1],E![2]*F![2]);
     else
         M := E![1]+F![1];
-        return ALGEBRAELEMENT@(FamilyObj(E),M,
-                       SUBS@(E![2],Correspondence(M)[1])*
-                       SUBS@(F![2],Correspondence(M)[2]));
+        return Fr.ALGEBRAELEMENT(FamilyObj(E),M,
+                       Fr.SUBS(E![2],Correspondence(M)[1])*
+                       Fr.SUBS(F![2],Correspondence(M)[2]));
     fi;
 end);
 
@@ -906,12 +906,12 @@ InstallMethod(\*, "for two linear elements", IsIdenticalObj,
         function(E,F)
     local M;
     if E![1]=F![1] then
-        return ALGEBRAELEMENT@(FamilyObj(E),E![1],LieBracket(E![2],F![2]));
+        return Fr.ALGEBRAELEMENT(FamilyObj(E),E![1],LieBracket(E![2],F![2]));
     else
         M := E![1]+F![1];
-        return ALGEBRAELEMENT@(FamilyObj(E),M,
-                       LieBracket(SUBS@(E![2],Correspondence(M)[1]),
-                               SUBS@(F![2],Correspondence(M)[2])));
+        return Fr.ALGEBRAELEMENT(FamilyObj(E),M,
+                       LieBracket(Fr.SUBS(E![2],Correspondence(M)[1]),
+                               Fr.SUBS(F![2],Correspondence(M)[2])));
     fi;
 end);
 
@@ -921,16 +921,16 @@ InstallMethod(PthPowerImage, "for a linear element",
     local p;
     p := Characteristic(LeftActingDomain(x));
     if not IsPrime(p) then TryNextMethod(); fi;
-    return ALGEBRAELEMENT@(FamilyObj(x),x![1],x![2]^p);
+    return Fr.ALGEBRAELEMENT(FamilyObj(x),x![1],x![2]^p);
 end);
-           
+
 InstallMethod(PthPowerImage, "for a linear element and a number",
         [IsLinearFRElement and IsFRElementStdRep and IsJacobianElement,IsInt],
         function(x,n)
     local p;
     p := Characteristic(LeftActingDomain(x));
     if not IsPrime(p) then TryNextMethod(); fi;
-    return ALGEBRAELEMENT@(FamilyObj(x),x![1],x![2]^(p^n));
+    return Fr.ALGEBRAELEMENT(FamilyObj(x),x![1],x![2]^(p^n));
 end);
 
 InstallMethod(\*, "for a scalar and a linear machine",
@@ -951,14 +951,14 @@ InstallMethod(\*, "for a scalar and a linear element",
         [IsScalar,IsLinearFRElement and IsFRElementStdRep],
         function(x,E)
     if not IsRat(x) and not x in LeftActingDomain(E) then TryNextMethod(); fi; # matrix?
-    return ALGEBRAELEMENT@(FamilyObj(E),E![1],x*E![2]);
+    return Fr.ALGEBRAELEMENT(FamilyObj(E),E![1],x*E![2]);
 end);
 
 InstallMethod(\*, "for a linear element and a scalar",
         [IsLinearFRElement and IsFRElementStdRep,IsScalar],
         function(E,x)
     if not IsRat(x) and not x in LeftActingDomain(E) then TryNextMethod(); fi; # matrix?
-    return ALGEBRAELEMENT@(FamilyObj(E),E![1],E![2]*x);
+    return Fr.ALGEBRAELEMENT(FamilyObj(E),E![1],E![2]*x);
 end);
 
 InstallMethod(\*, "(FR) for two linear elements", IsIdenticalObj,
@@ -1023,7 +1023,7 @@ InstallMethod(Minimized, "(FR) for a linear machine",
     trans := [];
     out := [];
     for j in [1..Length(gens)-2] do if imgs[j][1]<>fail then
-        Add(trans,MATRIX@(M!.transitions[j],v->SUBS@(v,gens)));
+        Add(trans,Fr.MATRIX(M!.transitions[j],v->Fr.SUBS(v,gens)));
         Add(out,M!.output[j]);
     fi; od;
     Add(trans,Zero(trans[1]));
@@ -1080,18 +1080,18 @@ if IsPackageMarkedForLoading("gbnp","") then
 
 ReadPackage("FR","gap/linear-gbnp.gi");
 
-else    
+else
 
-BindGlobal("ALGEBRAISZERO@", function(M,x)
+Fr.ALGEBRAISZERO := ( function(M,x)
     local zero, todo, i;
 
     zero := Subspace(M!.free,[]);
     todo := NewFIFO([x]);
     for x in todo do
         if not x in zero then
-            if not IsZero(SUBS@(x,M!.output)) then return false; fi;
+            if not IsZero(Fr.SUBS(x,M!.output)) then return false; fi;
             zero := ClosureLeftModule(zero,x);
-            x := SUBS@(x,M!.transitions);
+            x := Fr.SUBS(x,M!.transitions);
             for i in x do Append(todo,i); od;
         fi;
     od;
@@ -1106,12 +1106,12 @@ InstallMethod(\=, "(FR) for two linear elements", IsIdenticalObj,
         function(E,F)
     local M;
     if IsIdenticalObj(E![1], F![1]) then
-        return ALGEBRAISZERO@(E![1],E![2]-F![2]);
+        return Fr.ALGEBRAISZERO(E![1],E![2]-F![2]);
     else
         M := E![1]+F![1];
-        return ALGEBRAISZERO@(M,
-                       SUBS@(E![2],Correspondence(M)[1])-
-                       SUBS@(F![2],Correspondence(M)[2]));
+        return Fr.ALGEBRAISZERO(M,
+                       Fr.SUBS(E![2],Correspondence(M)[1])-
+                       Fr.SUBS(F![2],Correspondence(M)[2]));
     fi;
 end);
 
@@ -1152,8 +1152,8 @@ InstallMethod(\<, "(FR) for two linear elements", IsIdenticalObj,
         for p in [1,2] do
             if i <= Length(todo[p]) then
                 idle[p] := false;
-                x := SUBS@(todo[p][i],mach[p]!.transitions);
-                Add(out[p],SUBS@(todo[p][i],mach[p]!.output));
+                x := Fr.SUBS(todo[p][i],mach[p]!.transitions);
+                Add(out[p],Fr.SUBS(todo[p][i],mach[p]!.output));
                 t := [];
                 Add(trans[p],t);
                 for a in x do
@@ -1217,13 +1217,13 @@ end);
 InstallMethod(IsOne, "(FR) for a linear element",
         [IsLinearFRElement and IsFRElementStdRep],
         function(E)
-    return ALGEBRAISZERO@(E![1],E![2]-One(E![1]!.free));
+    return Fr.ALGEBRAISZERO(E![1],E![2]-One(E![1]!.free));
 end);
 
 InstallMethod(IsZero, "(FR) for a linear element",
         [IsLinearFRElement and IsFRElementStdRep],
         function(E)
-    return ALGEBRAISZERO@(E![1],E![2]);
+    return Fr.ALGEBRAISZERO(E![1],E![2]);
 end);
 ############################################################################
 
@@ -1275,18 +1275,18 @@ end,
         for i in [1..m] do
             x := Length(GeneratorsOfAlgebraWithOne(info.gens[i]![1]!.free));
             o := Concatenation(GeneratorsOfAlgebraWithOne(machine!.free){[j+1..j+x]},[Zero(machine!.free),One(machine!.free)]);
-            Add(todo[3],SUBS@(info.gens[i]![2],o));
+            Add(todo[3],Fr.SUBS(info.gens[i]![2],o));
             j := j+x;
         od;
         machine := Minimized(machine);
         for i in [1..m] do
-            todo[3][i] := SUBS@(todo[3][i],Correspondence(machine));
+            todo[3][i] := Fr.SUBS(todo[3][i],Correspondence(machine));
         od;
     fi;
     todo := NewFIFO([todo]);
 
     for t in todo do
-        o := List(t[3],v->SUBS@(v,machine!.output));
+        o := List(t[3],v->Fr.SUBS(v,machine!.output));
         if not o in image then
             image := ClosureLeftModule(image,o);
             Add(info.where,[t[1],t[2],o]);
@@ -1295,7 +1295,7 @@ end,
                 break;
             fi;
         fi;
-        x := List(t[3],e->SUBS@(e,machine!.transitions));
+        x := List(t[3],e->Fr.SUBS(e,machine!.transitions));
         # !!! and reduce... keep space of FreeAlgebra-tuples that have been considered.
         # unfortunately, GAP cannot handle vector spaces over machine!.free
         for i in [1..n] do

--- a/gap/mealy.gi
+++ b/gap/mealy.gi
@@ -26,7 +26,7 @@ InstallMethod(InitialState, "(FR) for a Mealy machine",
 #O Activity(<MealyElement>[, <Level>])
 #O WreathRecursion(<MealyElement>)
 ##
-BindGlobal("DOMALPHABET@", function(M)
+Fr.DOMALPHABET := ( function(M)
     local a;
     a := AlphabetOfFRObject(M);
     if IsDomain(a) then return a; else return Domain(a); fi;
@@ -53,14 +53,14 @@ end);
 InstallMethod(Output, "(FR) for a Mealy machine",
         [IsMealyMachine and IsMealyMachineDomainRep], 20,
         function(M)
-    return s->MappingByFunction(DOMALPHABET@(M), DOMALPHABET@(M),
+    return s->MappingByFunction(Fr.DOMALPHABET(M), Fr.DOMALPHABET(M),
                    a->M!.output(s,a));
 end);
 
 InstallMethod(Output, "(FR) for a Mealy machine and a state",
         [IsMealyMachine and IsMealyMachineDomainRep, IsObject], 20,
         function(M, s)
-    return MappingByFunction(DOMALPHABET@(M), DOMALPHABET@(M),
+    return MappingByFunction(Fr.DOMALPHABET(M), Fr.DOMALPHABET(M),
                    a->M!.output(s,a));
 end);
 
@@ -89,7 +89,7 @@ end);
 InstallMethod(Output, "(FR) for a Mealy element",
         [IsMealyElement and IsMealyMachineDomainRep],
         function(E)
-    return MappingByFunction(DOMALPHABET@(E), DOMALPHABET@(E),
+    return MappingByFunction(Fr.DOMALPHABET(E), Fr.DOMALPHABET(E),
                    a->E!.output(E!.initial,a));
 end);
 
@@ -177,7 +177,7 @@ InstallMethod(Transitions, "(FR) for a Mealy element",
     return i->M!.transitions(M!.initial,i);
 end);
 
-BindGlobal("MMACTIVITY@", function(E,l)
+Fr.MMACTIVITY := ( function(E,l)
     local d, i, r, s;
     d := Size(AlphabetOfFRObject(E));
     r := List([1..E!.nrstates], i->[1]);
@@ -191,19 +191,19 @@ end);
 InstallMethod(Activity, "(FR) for a Mealy element and a level",
         [IsMealyElement, IsInt],
         function(E,l)
-    return PERMORTRANSFORMATION@(Transformation(MMACTIVITY@(E,l)[E!.initial]));
+    return Fr.PERMORTRANSFORMATION(Transformation(Fr.MMACTIVITY(E,l)[E!.initial]));
 end);
 
 InstallMethod(ActivityTransformation, "(FR) for a Mealy element and a level",
         [IsMealyElement, IsInt],
         function(E,l)
-    return Transformation(MMACTIVITY@(E,l)[E!.initial]);
+    return Transformation(Fr.MMACTIVITY(E,l)[E!.initial]);
 end);
 
 InstallMethod(ActivityPerm, "(FR) for a Mealy element and a level",
         [IsMealyElement, IsInt],
         function(E,l)
-    return PermList(MMACTIVITY@(E,l)[E!.initial]);
+    return PermList(Fr.MMACTIVITY(E,l)[E!.initial]);
 end);
 
 InstallMethod(\^, "(FR) for an integer and a Mealy element",
@@ -266,7 +266,7 @@ end);
 InstallMethod(GeneratorsOfFRMachine, "(FR) for a Mealy machine",
         [IsMealyMachine], StateSet);
 
-BindGlobal("MEALYLIMITSTATES@", function(M)
+Fr.MEALYLIMITSTATES := ( function(M)
     local R, oldR, i, a;
     R := BlistList([1..M!.nrstates],[1..M!.nrstates]);
     repeat
@@ -281,14 +281,14 @@ end);
 
 InstallMethod(LimitStatesOfFRMachine, "(FR) for a Mealy machine",
         [IsMealyMachine and IsMealyMachineIntRep],
-        M->List(MEALYLIMITSTATES@(M),i->FRElement(M,i)));
+        M->List(Fr.MEALYLIMITSTATES(M),i->FRElement(M,i)));
 InstallMethod(LimitStates,  "(FR) for a Mealy machine",
         [IsMealyMachine and IsMealyMachineIntRep],
         LimitStatesOfFRMachine);
 
 InstallMethod(LimitStatesOfFRElement, "(FR) for a Mealy element",
         [IsMealyElement and IsMealyMachineIntRep],
-        E->List(MEALYLIMITSTATES@(E),i->FRElement(E,i)));
+        E->List(Fr.MEALYLIMITSTATES(E),i->FRElement(E,i)));
 
 InstallOtherMethod(State, "(FR) for a Mealy element and an integer",
         [IsMealyElement, IsInt],
@@ -346,7 +346,7 @@ end);
 # mode=0 means normal
 # mode=1 means all states are known to be accessible
 # mode=2 means all states are known to be distinct and accessible
-BindGlobal("MMMINIMIZE@", function(fam,alphabet,nrstates,transitions,output,initial,mode)
+Fr.MMMINIMIZE := ( function(fam,alphabet,nrstates,transitions,output,initial,mode)
     local a, sn, snart, part, trap, i, j, x, y, p, ci, todo, states;
 
     if initial<>fail and mode=0 then
@@ -471,14 +471,14 @@ InstallMethod(Minimized, "(FR) for a Mealy machine in int rep",
     if M!.output=[] then
         return M;
     else
-        return MMMINIMIZE@(FamilyObj(M),AlphabetOfFRObject(M),
+        return Fr.MMMINIMIZE(FamilyObj(M),AlphabetOfFRObject(M),
                        M!.nrstates,M!.transitions,M!.output,fail,0);
     fi;
 end);
 
 InstallMethod(Minimized, "(FR) for a Mealy element in int rep",
         [IsMealyElement and IsMealyMachineIntRep],
-        E->MMMINIMIZE@(FamilyObj(E),AlphabetOfFRObject(E),
+        E->Fr.MMMINIMIZE(FamilyObj(E),AlphabetOfFRObject(E),
                 E!.nrstates,E!.transitions,E!.output,E!.initial,0));
 
 InstallMethod(Minimized, "(FR) for a Mealy machine in domain rep",
@@ -535,7 +535,7 @@ InstallMethod(MealyElementNC, "(FR) for a family, two matrices and an initial st
                        initial := initial));
 end);
 
-BindGlobal("MEALYMACHINEINT@", function(transitions, output, initial)
+Fr.MEALYMACHINEINT := ( function(transitions, output, initial)
     local F, nrstates, i, out, inv;
     if Length(transitions)<>Length(output) then
         Error("<Transitions> and <Output> must have the same length\n");
@@ -553,8 +553,8 @@ BindGlobal("MEALYMACHINEINT@", function(transitions, output, initial)
     if ForAny(transitions, x->ForAny(x, i->not i in [1..nrstates])) then
         Error("An entry of <Transitions> is not in the state set\n");
     fi;
-    out := List(output,x->ANY2OUT@(x,Size(F!.alphabet)));
-    inv := ForAll(out,ISINVERTIBLE@);
+    out := List(output,x->Fr.ANY2OUT(x,Size(F!.alphabet)));
+    inv := ForAll(out,Fr.ISINVERTIBLE);
     if ForAny(out, x->not IsSubset(F!.alphabet, x)) then
         Error("An entry of <Output> is not in the alphabet\n");
     fi;
@@ -579,13 +579,13 @@ end);
 
 InstallMethod(MealyMachine, "(FR) for a matrix and a list",
         [IsMatrix, IsList],
-        function(t, o) return MEALYMACHINEINT@(t, o, fail); end);
+        function(t, o) return Fr.MEALYMACHINEINT(t, o, fail); end);
 
 InstallMethod(MealyElement, "(FR) for a matrix, a list and a state",
         [IsMatrix, IsList, IsInt],
-        function(t, o, s) return MEALYMACHINEINT@(t, o, s); end);
+        function(t, o, s) return Fr.MEALYMACHINEINT(t, o, s); end);
 
-BindGlobal("MEALYMACHINEDOM@", function(alphabet, transitions, output, has_init, initial)
+Fr.MEALYMACHINEDOM := ( function(alphabet, transitions, output, has_init, initial)
     local F, out, trans, i, t;
     if has_init then
         F := FREFamily(alphabet);
@@ -615,7 +615,7 @@ BindGlobal("MEALYMACHINEDOM@", function(alphabet, transitions, output, has_init,
             if IsFunction(i) then
                 Add(out, MappingByFunction(alphabet, alphabet, i));
             else
-                Add(out, ANY2OUT@(i,Size(alphabet)));
+                Add(out, Fr.ANY2OUT(i,Size(alphabet)));
             fi;
         od;
         t := IsMealyMachineIntRep;
@@ -663,11 +663,11 @@ end);
 
 InstallMethod(MealyMachine, "(FR) for an alphabet and two lists",
         [IsDomain, IsList, IsList],
-        function(a, t, o) return MEALYMACHINEDOM@(a, t, o, false, 0); end);
+        function(a, t, o) return Fr.MEALYMACHINEDOM(a, t, o, false, 0); end);
 
 InstallMethod(MealyElement, "(FR) for an alphabet, two lists and a state",
         [IsDomain, IsList, IsList, IsInt],
-        function(a, t, o, s) return MEALYMACHINEDOM@(a, t, o, true, s); end);
+        function(a, t, o, s) return Fr.MEALYMACHINEDOM(a, t, o, true, s); end);
 
 InstallMethod(MealyMachine, "(FR) for alphabet, stateset and two functions",
         [IsDomain, IsDomain, IsFunction, IsFunction],
@@ -696,14 +696,14 @@ end);
 InstallMethod(FRElement, "(FR) for a Mealy machine and a state",
         [IsMealyMachine and IsMealyMachineIntRep, IsInt],
         function(M,s)
-    return MMMINIMIZE@(FREFamily(M),AlphabetOfFRObject(M),
+    return Fr.MMMINIMIZE(FREFamily(M),AlphabetOfFRObject(M),
                    M!.nrstates,M!.transitions,M!.output,s,0);
 end);
 
 InstallMethod(FRElement, "(FR) for a Mealy element and a state",
         [IsMealyElement and IsMealyMachineIntRep, IsInt],
         function(E,s)
-    return MMMINIMIZE@(FamilyObj(E),AlphabetOfFRObject(E),
+    return Fr.MMMINIMIZE(FamilyObj(E),AlphabetOfFRObject(E),
                    E!.nrstates,E!.transitions,E!.output,s,2);
 end);
 
@@ -741,7 +741,7 @@ InstallMethod(FRElement, "(FR) for a Mealy element and a state",
                        initial := s));
 end);
 
-BindGlobal("COMPOSEELEMENT@", function(l,p)
+Fr.COMPOSEELEMENT := ( function(l,p)
     local m, i, init;
     if ForAll(l,IsMealyElement) then
         m := MealyMachineNC(FRMFamily(l[1]),[List(l,x->1)],[p]);
@@ -760,12 +760,12 @@ end);
 InstallMethod(ComposeElement, "(FR) for a list of elements and a permutation",
         [IsFRElementCollection, IsObject],
         function(l,p)
-    return COMPOSEELEMENT@(l,ANY2OUT@(p,Size(AlphabetOfFRObject(l[1]))));
+    return Fr.COMPOSEELEMENT(l,Fr.ANY2OUT(p,Size(AlphabetOfFRObject(l[1]))));
 end);
 
 InstallMethod(ComposeElement, "(FR) for a list of elements and a list",
         [IsFRElementCollection, IsList],
-        COMPOSEELEMENT@);
+        Fr.COMPOSEELEMENT);
 
 InstallMethod(VertexElement, "(FR) for a vertex index and a Mealy element",
         [IsPosInt, IsMealyElement],
@@ -796,7 +796,7 @@ InstallMethod(ViewString, "(FR) displays a Mealy machine in compact form",
         function(M)
     local s;
     s := "<Mealy machine on alphabet ";
-    APPEND@(s, AlphabetOfFRObject(M), " with ", M!.nrstates, " state");
+    Fr.APPEND(s, AlphabetOfFRObject(M), " with ", M!.nrstates, " state");
     if M!.nrstates<>1 then Append(s,"s"); fi;
     Append(s,">");
     return s;
@@ -804,19 +804,19 @@ end);
 
 InstallMethod(ViewString, "(FR) displays a Mealy machine in compact form",
         [IsMealyMachine and IsMealyMachineDomainRep],
-        M->CONCAT@("<Mealy machine on alphabet ", AlphabetOfFRObject(M), " with states ", M!.states,">"));
+        M->Fr.CONCAT("<Mealy machine on alphabet ", AlphabetOfFRObject(M), " with states ", M!.states,">"));
 
 InstallMethod(ViewString, "(FR) displays a Mealy element in compact form",
         [IsMealyElement and IsMealyMachineIntRep],
         function(E)
     local s;
     if IsOne(E) then
-        s := CONCAT@("<Trivial Mealy element on alphabet ", AlphabetOfFRObject(E), ">");
+        s := Fr.CONCAT("<Trivial Mealy element on alphabet ", AlphabetOfFRObject(E), ">");
     else
-        s := CONCAT@("<Mealy element on alphabet ", AlphabetOfFRObject(E),
+        s := Fr.CONCAT("<Mealy element on alphabet ", AlphabetOfFRObject(E),
             " with ", E!.nrstates, " state");
         if E!.nrstates<>1 then Append(s,"s"); fi;
-        if E!.initial<>1 then APPEND@(s,", initial state ",E!.initial); fi;
+        if E!.initial<>1 then Fr.APPEND(s,", initial state ",E!.initial); fi;
         Append(s,">");
     fi;
     return s;
@@ -824,7 +824,7 @@ end);
 
 InstallMethod(ViewString, "(FR) displays a Mealy element in compact form",
         [IsMealyElement and IsMealyMachineDomainRep],
-        E->CONCAT@("<Mealy element on alphabet ", AlphabetOfFRObject(E),
+        E->Fr.CONCAT("<Mealy element on alphabet ", AlphabetOfFRObject(E),
         " with states ", E!.states, ", initial state ", InitialState(E), ">"));
 #############################################################################
 
@@ -834,21 +834,21 @@ InstallMethod(ViewString, "(FR) displays a Mealy element in compact form",
 ##
 InstallMethod(String, "(FR) Mealy machine to string",
         [IsMealyMachine and IsMealyMachineIntRep],
-        M->CONCAT@("MealyMachine(",M!.transitions,", ", M!.output,")"));
+        M->Fr.CONCAT("MealyMachine(",M!.transitions,", ", M!.output,")"));
 
 InstallMethod(String, "(FR) Mealy element to string",
         [IsMealyElement and IsMealyMachineIntRep],
-        E->CONCAT@("MealyElement(",E!.transitions,", ",
+        E->Fr.CONCAT("MealyElement(",E!.transitions,", ",
                    E!.output,", ",InitialState(E),")"));
 
 InstallMethod(String, "(FR) Mealy machine to string",
         [IsMealyMachine and IsMealyMachineDomainRep],
-        M->CONCAT@("MealyMachine(",M!.states,", ", AlphabetOfFRObject(M),
+        M->Fr.CONCAT("MealyMachine(",M!.states,", ", AlphabetOfFRObject(M),
                 ", ",M!.transitions, ", ",M!.output,")"));
 
 InstallMethod(String, "(FR) Mealy element to string",
         [IsMealyElement and IsMealyMachineDomainRep],
-        E->CONCAT@("MealyElement(",E!.states,", ", AlphabetOfFRObject(E),
+        E->Fr.CONCAT("MealyElement(",E!.states,", ", AlphabetOfFRObject(E),
                 ", ",E!.transitions,", ",E!.output,", ",InitialState(E),")"));
 #############################################################################
 
@@ -856,7 +856,7 @@ InstallMethod(String, "(FR) Mealy element to string",
 ##
 #M  Display . . . . . . . . . . . . . . . . . . . .pretty-print Mealy machine
 ##
-BindGlobal("MEALYDISPLAY@", function(M)
+Fr.MEALYDISPLAY := ( function(M)
     local a, i, j, states, slen, alen, sprint, aprint, sblank, ablank, srule, arule, s;
     a := AlphabetOfFRObject(M);
     states := StateSet(M);
@@ -880,28 +880,28 @@ BindGlobal("MEALYDISPLAY@", function(M)
     arule := ListWithIdenticalEntries(alen,'-');
 
     s := Concatenation(sblank," |");
-    for i in a do APPEND@(s,sblank,aprint(i)," "); od;
-    APPEND@(s,"\n");
-    APPEND@(s,srule,"-+"); for i in a do APPEND@(s,srule,arule,"+"); od; APPEND@(s,"\n");
+    for i in a do Fr.APPEND(s,sblank,aprint(i)," "); od;
+    Fr.APPEND(s,"\n");
+    Fr.APPEND(s,srule,"-+"); for i in a do Fr.APPEND(s,srule,arule,"+"); od; Fr.APPEND(s,"\n");
     for i in states do
-        APPEND@(s,sprint(i)," |");
+        Fr.APPEND(s,sprint(i)," |");
         for j in a do
-            APPEND@(s,sprint(Transition(M,i,j)),",",aprint(Output(M,i,j)));
+            Fr.APPEND(s,sprint(Transition(M,i,j)),",",aprint(Output(M,i,j)));
         od;
-        APPEND@(s,"\n");
+        Fr.APPEND(s,"\n");
     od;
-    APPEND@(s,srule,"-+"); for i in a do APPEND@(s,srule,arule,"+"); od; APPEND@(s,"\n");
+    Fr.APPEND(s,srule,"-+"); for i in a do Fr.APPEND(s,srule,arule,"+"); od; Fr.APPEND(s,"\n");
     if IsMealyElement(M) then
-        APPEND@(s,"Initial state:",sprint(InitialState(M)),"\n");
+        Fr.APPEND(s,"Initial state:",sprint(InitialState(M)),"\n");
     fi;
     return s;
 end);
 
 InstallMethod(DisplayString, "(FR) for a Mealy machine",
-        [IsMealyMachine], MEALYDISPLAY@);
+        [IsMealyMachine], Fr.MEALYDISPLAY);
 
 InstallMethod(DisplayString, "(FR) for a Mealy element",
-        [IsMealyElement], MEALYDISPLAY@);
+        [IsMealyElement], Fr.MEALYDISPLAY);
 #############################################################################
 
 ############################################################################
@@ -915,7 +915,7 @@ InstallMethod(DisplayString, "(FR) for a Mealy element",
 #M  AsMonoidFRElement
 #M  AsSemigroupFRElement
 ##
-BindGlobal("DOMAINTOPERMTRANS@", function(X)
+Fr.DOMAINTOPERMTRANS := ( function(X)
     local a, s, i, t, out, trans;
     a := AsSortedList(AlphabetOfFRObject(X));
     s := AsSortedList(X!.states);
@@ -937,7 +937,7 @@ BindGlobal("DOMAINTOPERMTRANS@", function(X)
     return i;
 end);
 
-BindGlobal("MAKEMEALYMACHINE@", function(f,l,init)
+Fr.MAKEMEALYMACHINE := ( function(f,l,init)
     local M, d;
     d := List(l,DecompositionOfFRElement);
     M := List(d,x->List(x[1],y->Position(l,y)));
@@ -950,16 +950,16 @@ BindGlobal("MAKEMEALYMACHINE@", function(f,l,init)
     fi;
 end);
 
-BindGlobal("ASINTREP@", function(M)
+Fr.ASINTREP := ( function(M)
     if IsMealyMachineIntRep(M) then
         return M;
     elif IsMealyMachineDomainRep(M) then
-        return DOMAINTOPERMTRANS@(M);
+        return Fr.DOMAINTOPERMTRANS(M);
     elif IsFRMachine(M) then
-        return MAKEMEALYMACHINE@(FamilyObj(M),
+        return Fr.MAKEMEALYMACHINE(FamilyObj(M),
             States(List(GeneratorsOfFRMachine(M),x->FRElement(M,x))),fail);
     else
-        return MAKEMEALYMACHINE@(FamilyObj(M),States(M),M);
+        return Fr.MAKEMEALYMACHINE(FamilyObj(M),States(M),M);
     fi;
 end);
 
@@ -967,7 +967,7 @@ InstallMethod(AsMealyMachine, "(FR) for a list of FR elements",
         [IsFRElementCollection],
         function(l)
     local M, d;
-    M := MAKEMEALYMACHINE@(FamilyObj(UnderlyingFRMachine(l[1])),l,fail);
+    M := Fr.MAKEMEALYMACHINE(FamilyObj(UnderlyingFRMachine(l[1])),l,fail);
     SetCorrespondence(M,l);
     return M;
 end);
@@ -978,7 +978,7 @@ InstallMethod(AsMealyMachine, "(FR) for a FR machine",
     local gens, states, N;
     gens := List(GeneratorsOfFRMachine(M),x->FRElement(M,x));
     states := States(gens);
-    N := MAKEMEALYMACHINE@(FamilyObj(M),states,fail);
+    N := Fr.MAKEMEALYMACHINE(FamilyObj(M),states,fail);
     SetCorrespondence(N,MappingByFunction(StateSet(M),Integers,g->Position(states,g)));
     return N;
 end);
@@ -992,7 +992,7 @@ end);
 
 InstallMethod(AsMealyElement, "(FR) for a FR element",
         [IsFRElement],
-        E->MAKEMEALYMACHINE@(FamilyObj(E),States(E),E));
+        E->Fr.MAKEMEALYMACHINE(FamilyObj(E),States(E),E));
 
 InstallMethod(AsMealyElement, "(FR) for a Mealy element",
         [IsMealyElement], E->E);
@@ -1001,7 +1001,7 @@ InstallMethod(AsGroupFRMachine, "(FR) for a Mealy machine",
         [IsMealyMachine],
         function(M)
     local G, gen, gens, realm, ntrealm, corr, i, e;
-    M := ASINTREP@(M);
+    M := Fr.ASINTREP(M);
     if not IsInvertible(M) then return fail; fi;
     realm := StateSet(M);
     corr := []; ntrealm := []; gens := [];
@@ -1031,7 +1031,7 @@ InstallMethod(AsMonoidFRMachine, "(FR) for a Mealy machine",
         [IsMealyMachine],
         function(M)
     local G, gen, gens, realm, ntrealm, corr, i, e;
-    M := ASINTREP@(M);
+    M := Fr.ASINTREP(M);
     realm := StateSet(M);
     corr := []; ntrealm := []; gens := [];
     for i in realm do
@@ -1058,7 +1058,7 @@ InstallMethod(AsSemigroupFRMachine, "(FR) for a Mealy machine",
         [IsMealyMachine],
         function(M)
     local G, gen, gens, realm, ntrealm, corr, i, e;
-    M := ASINTREP@(M);
+    M := Fr.ASINTREP(M);
     realm := StateSet(M);
     corr := []; ntrealm := []; gens := [];
     for i in realm do
@@ -1104,14 +1104,14 @@ end);
 InstallMethod(AsIntMealyMachine, "(FR) for a Mealy machine",
         [IsMealyMachine and IsMealyMachineIntRep], AsMealyMachine);
 InstallMethod(AsIntMealyMachine, "(FR) for a Mealy machine",
-        [IsMealyMachine], DOMAINTOPERMTRANS@);
+        [IsMealyMachine], Fr.DOMAINTOPERMTRANS);
 
 InstallMethod(AsIntMealyElement, "(FR) for a Mealy machine",
         [IsMealyElement and IsMealyMachineIntRep], AsMealyElement);
 InstallMethod(AsIntMealyElement, "(FR) for a Mealy machine",
-        [IsMealyElement], DOMAINTOPERMTRANS@);
+        [IsMealyElement], Fr.DOMAINTOPERMTRANS);
 
-BindGlobal("TOPELEMENTPERM@", function(l)
+Fr.TOPELEMENTPERM := ( function(l)
     local n;
     n := Length(l);
     if l=[1..n] then
@@ -1124,19 +1124,19 @@ BindGlobal("TOPELEMENTPERM@", function(l)
 end);
 InstallMethod(TopElement, "(FR) for a permutation",
         [IsPerm],
-        p->TOPELEMENTPERM@(ListPerm(p)));
+        p->Fr.TOPELEMENTPERM(ListPerm(p)));
 InstallMethod(TopElement, "(FR) for a permutation and a degree",
         [IsPerm,IsInt],
         function(p,n)
-    return TOPELEMENTPERM@(ListPerm(p,n));
+    return Fr.TOPELEMENTPERM(ListPerm(p,n));
 end);
 InstallMethod(TopElement, "(FR) for a transformation",
         [IsTransformation],
-        t->TOPELEMENTPERM@(ListTransformation(t)));
+        t->Fr.TOPELEMENTPERM(ListTransformation(t)));
 InstallMethod(TopElement, "(FR) for a transformation and a degree",
         [IsTransformation,IsInt],
         function(t,n)
-    return TOPELEMENTPERM@(ListTransformation(t,n));
+    return Fr.TOPELEMENTPERM(ListTransformation(t,n));
 end);
 #############################################################################
 
@@ -1144,7 +1144,7 @@ end);
 ##
 #M  Draw . . . . . . . . . . . . . . . . . .draw Mealy machine using graphviz
 ##
-BindGlobal("MM2DOT@", function(M)
+Fr.MM2DOT := ( function(M)
     local names, i, j, S, stateset, alphabet;
 
     S := "digraph ";
@@ -1185,7 +1185,7 @@ BindGlobal("MM2DOT@", function(M)
             Append(S,"/");
             Append(S,String(Output(M,stateset[i],j)));
             Append(S,"\",color=");
-            Append(S,COLOURS@(Position(alphabet,j)));
+            Append(S,Fr.COLOURS(Position(alphabet,j)));
             Append(S,"];\n");
         od;
     od;
@@ -1193,75 +1193,75 @@ BindGlobal("MM2DOT@", function(M)
     return S;
 end);
 
-BindGlobal("DRAWMEALY@", function(M)
+Fr.DRAWMEALY := ( function(M)
      # more a hack than a clean implementation...
     if IsBoundGlobal("JupyterRenderable") then
-        return ValueGlobal("JupyterRenderable")(rec(("image/svg+xml") :=IO_PipeThrough("dot",["-Tsvg"],MM2DOT@(M))),rec());
+        return ValueGlobal("JupyterRenderable")(rec(("image/svg+xml") :=IO_PipeThrough("dot",["-Tsvg"],Fr.MM2DOT(M))),rec());
     else
-        DOT2DISPLAY@(MM2DOT@(M),"dot");
+        Fr.DOT2DISPLAY(Fr.MM2DOT(M),"dot");
     fi;
 end);
 
 InstallMethod(Draw, "(FR) draws a Mealy machine using graphviz",
         [IsMealyMachine],
-        DRAWMEALY@);
+        Fr.DRAWMEALY);
 
 InstallMethod(Draw, "(FR) draws a Mealy machine using graphviz",
         [IsMealyMachine, IsString],
         function(M,str)
-    AppendTo(str,MM2DOT@(M));
+    AppendTo(str,Fr.MM2DOT(M));
 end);
 
 InstallMethod(Draw, "(FR) draws a Mealy element using graphviz",
         [IsMealyElement],
-        DRAWMEALY@);
+        Fr.DRAWMEALY);
 
 InstallMethod(Draw, "(FR) draws a Mealy element using graphviz",
         [IsMealyElement, IsString],
         function(M,str)
-    AppendTo(str,MM2DOT@(M));
+    AppendTo(str,Fr.MM2DOT(M));
 end);
 
-BindGlobal("INSTALLMMHANDLER@", function(name,rv)
+Fr.INSTALLMMHANDLER := ( function(name,rv)
     InstallOtherMethod(name, "(FR) for a generic Mealy machine",
             [IsFRMachine],
             function(M)
         Info(InfoFR, 2, name, ": converting to Mealy machine");
         if rv then
-            return name(ASINTREP@(M));
+            return name(Fr.ASINTREP(M));
         else
-            name(ASINTREP@(M));
+            name(Fr.ASINTREP(M));
         fi;
     end);
 end);
-BindGlobal("INSTALLMEHANDLER@", function(name,rv)
+Fr.INSTALLMEHANDLER := ( function(name,rv)
     InstallOtherMethod(name, "(FR) for a generic Mealy element",
             [IsFRElement],
             function(E)
         Info(InfoFR, 2, name, ": converting to Mealy element");
         if rv then
-            return name(ASINTREP@(E));
+            return name(Fr.ASINTREP(E));
         else
-            name(ASINTREP@(E));
+            name(Fr.ASINTREP(E));
         fi;
     end);
 end);
 
-INSTALLMEHANDLER@(Draw,false);
-INSTALLMMHANDLER@(Draw,false);
+Fr.INSTALLMEHANDLER(Draw,false);
+Fr.INSTALLMMHANDLER(Draw,false);
 
 InstallOtherMethod(Draw, "(FR) for a FR machine and a filename",
         [IsFRMachine,IsString],
         function(M,S)
     Info(InfoFR, 1, "Draw: converting to Mealy machine");
-    Draw(ASINTREP@(M),S);
+    Draw(Fr.ASINTREP(M),S);
 end);
 
 InstallOtherMethod(Draw, "(FR) for a FR element and a filename",
         [IsFRElement,IsString],
         function(E,S)
     Info(InfoFR, 1, "Draw: converting to Mealy element");
-    Draw(ASINTREP@(E),S);
+    Draw(Fr.ASINTREP(E),S);
 end);
 ############################################################################
 
@@ -1274,7 +1274,7 @@ InstallMethod(IsOne, "(FR) for a Mealy element",
         function(E)
     return E!.output = [AlphabetOfFRObject(E)];
 end);
-INSTALLMEHANDLER@(IsOne,true);
+Fr.INSTALLMEHANDLER(IsOne,true);
 
 InstallMethod(\=, "(FR) for two Mealy elements", IsIdenticalObj,
         [IsMealyElement and IsMealyMachineIntRep, IsMealyElement and IsMealyMachineIntRep],
@@ -1315,7 +1315,7 @@ InstallMethod(IsOne, "(FR) for a Mealy machine",
         function(x)
     local ix;
     if IsFinite(AlphabetOfFRObject(x)) then
-        ix := ASINTREP@(x);
+        ix := Fr.ASINTREP(x);
         return ix!.output=[AlphabetOfFRObject(x)];
     else
         TryNextMethod();
@@ -1334,7 +1334,7 @@ InstallMethod(\=, "(FR) for two Mealy machines in domain rep", IsIdenticalObj,
         [IsMealyMachine and IsMealyMachineDomainRep, IsMealyMachine and IsMealyMachineDomainRep],
         function(x,y)
     if IsFinite(AlphabetOfFRObject(x)) then
-        return ASINTREP@(x)=ASINTREP@(y);
+        return Fr.ASINTREP(x)=Fr.ASINTREP(y);
     else
         return x!.nrstates = y!.nrstates and
                x!.transitions = y!.transitions and
@@ -1349,10 +1349,10 @@ InstallMethod(\=, "(FR) for two Mealy elements", IsIdenticalObj,
         Error("Don't know how to compare machines in domain representation");
     fi;
     if IsMealyMachineDomainRep(x) then
-        x := ASINTREP@(x);
+        x := Fr.ASINTREP(x);
     fi;
     if IsMealyMachineDomainRep(y) then
-        y := ASINTREP@(y);
+        y := Fr.ASINTREP(y);
     fi;
     return x=y;
 end);
@@ -1365,7 +1365,7 @@ InstallMethod(\<, "(FR) for two Mealy machines", IsIdenticalObj,
         [IsMealyMachine and IsMealyMachineDomainRep, IsMealyMachine and IsMealyMachineIntRep],
         ReturnFalse);
 
-BindGlobal("MMLTINTREP@", function(x,y)
+Fr.MMLTINTREP := ( function(x,y)
     local a, s;
     if x!.nrstates <> y!.nrstates then
         return x!.nrstates < y!.nrstates;
@@ -1378,13 +1378,13 @@ end);
 
 InstallMethod(\<, "(FR) for two Mealy machines", IsIdenticalObj,
         [IsMealyMachine and IsMealyMachineIntRep, IsMealyMachine and IsMealyMachineIntRep],
-        MMLTINTREP@);
+        Fr.MMLTINTREP);
 
 InstallMethod(\<, "(FR) for two Mealy machines", IsIdenticalObj,
         [IsMealyMachine and IsMealyMachineDomainRep, IsMealyMachine and IsMealyMachineDomainRep],
         function(x,y)
     if IsFinite(AlphabetOfFRObject(x)) then
-        return MMLTINTREP@(ASINTREP@(x), ASINTREP@(y));
+        return Fr.MMLTINTREP(Fr.ASINTREP(x), Fr.ASINTREP(y));
     else
         if x!.nrstates <> y!.nrstates then
             return x!.nrstates < y!.nrstates;
@@ -1404,10 +1404,10 @@ InstallMethod(\<, "(FR) for two Mealy elements", IsIdenticalObj,
         Error("Don't know how to compare machines in domain representation");
     fi;
     if IsMealyMachineDomainRep(x) then
-        x := ASINTREP@(x);
+        x := Fr.ASINTREP(x);
     fi;
     if IsMealyMachineDomainRep(y) then
-        y := ASINTREP@(y);
+        y := Fr.ASINTREP(y);
     fi;
     return x<y;
 end);
@@ -1434,7 +1434,7 @@ InstallMethod(\+, "(FR) for two Mealy machines", IsIdenticalObj,
         SetIsInvertible(a,ForAll(arg,IsInvertible));
     fi;
     SetCorrespondence(a,i->MappingByFunction(arg[i]!.states,q,s->[i,s]));
-    SET_NAME@(arg,"+",a);
+    Fr.SET_NAME(arg,"+",a);
     return a;
 end);
 
@@ -1450,14 +1450,14 @@ InstallMethod(\+, "(FR) for two Mealy machines", IsIdenticalObj,
         SetIsInvertible(a,IsInvertible(M) and IsInvertible(N));
     fi;
     SetCorrespondence(a,[IdentityTransformation,TransformationListList([1..N!.nrstates],M!.nrstates+[1..N!.nrstates])]);
-    SET_NAME@([M,N],"+",a);
+    Fr.SET_NAME([M,N],"+",a);
     return a;
 end);
 
 InstallMethod(\+, "(FR) for generic FR machines", IsIdenticalObj,
         [IsFRMachine,IsFRMachine],
         function(x,y)
-    return ASINTREP@(x)+ASINTREP@(y);
+    return Fr.ASINTREP(x)+Fr.ASINTREP(y);
 end);
 
 InstallMethod(\*, "(FR) for two Mealy machines", IsIdenticalObj,
@@ -1476,7 +1476,7 @@ InstallMethod(\*, "(FR) for two Mealy machines", IsIdenticalObj,
     if HasIsInvertible(M) and HasIsInvertible(N) then
         SetIsInvertible(a,IsInvertible(M) and IsInvertible(N));
     fi;
-    SET_NAME@([M,N],"*",a);
+    Fr.SET_NAME([M,N],"*",a);
     return a;
 end);
 
@@ -1500,14 +1500,14 @@ InstallMethod(\*, "(FR) for two Mealy machines", IsIdenticalObj,
     if HasIsInvertible(M) and HasIsInvertible(N) then
         SetIsInvertible(a,IsInvertible(M) and IsInvertible(N));
     fi;
-    SET_NAME@([M,N],"*",a);
+    Fr.SET_NAME([M,N],"*",a);
     return a;
 end);
 
 InstallMethod(\*, "(FR) for generic FR machines", IsIdenticalObj,
         [IsFRMachine,IsFRMachine],
         function(x,y)
-    return ASINTREP@(x)*ASINTREP@(y);
+    return Fr.ASINTREP(x)*Fr.ASINTREP(y);
 end);
 
 InstallMethod(TensorProductOp, "(FR) for Mealy machines",
@@ -1537,7 +1537,7 @@ InstallMethod(TensorProductOp, "(FR) for Mealy machines",
     if ForAll(M,HasIsInvertible) then
         SetIsInvertible(a,ForAll(M,IsInvertible));
     fi;
-    SET_NAME@(M,"(*)",a);
+    Fr.SET_NAME(M,"(*)",a);
     return a;
 end);
 
@@ -1574,14 +1574,14 @@ InstallMethod(TensorProductOp, "(FR) for two integer Mealy machines",
     if ForAll(M,HasIsInvertible) then
         SetIsInvertible(a,ForAll(M,IsInvertible));
     fi;
-    SET_NAME@(M,"(*)",a);
+    Fr.SET_NAME(M,"(*)",a);
     return a;
 end);
 
 InstallMethod(TensorProductOp, "(FR) for generic FR machines",
         [IsList,IsFRMachine],
         function(M,N)
-    M := List(M,ASINTREP@);
+    M := List(M,Fr.ASINTREP);
     return TensorProductOp(M,M[1]);
 end);
 
@@ -1605,7 +1605,7 @@ InstallMethod(TensorSumOp, "(FR) for two Mealy machines",
     if ForAll(M,HasIsInvertible) then
         SetIsInvertible(a,ForAll(M,IsInvertible));
     fi;
-    SET_NAME@(M,"(+)",a);
+    Fr.SET_NAME(M,"(+)",a);
     return a;
 end);
 
@@ -1636,14 +1636,14 @@ InstallMethod(TensorSumOp, "(FR) for two integer Mealy machines",
     if ForAll(M,HasIsInvertible) then
         SetIsInvertible(a,ForAll(M,IsInvertible));
     fi;
-    SET_NAME@(M,"(+)",a);
+    Fr.SET_NAME(M,"(+)",a);
     return a;
 end);
 
 InstallMethod(TensorSumOp, "(FR) for generic FR machines",
         [IsList,IsFRMachine],
         function(M,N)
-    M := List(M,ASINTREP@);
+    M := List(M,Fr.ASINTREP);
     return TensorSumOp(M,M[1]);
 end);
 
@@ -1673,7 +1673,7 @@ InstallMethod(DirectSumOp, "(FR) for two Mealy machines",
     if ForAll(M,HasIsInvertible) then
         SetIsInvertible(a,ForAll(M,IsInvertible));
     fi;
-    SET_NAME@(M,"(+)",a);
+    Fr.SET_NAME(M,"(+)",a);
     return a;
 end);
 
@@ -1708,14 +1708,14 @@ InstallMethod(DirectSumOp, "(FR) for two integer Mealy machines",
     if ForAll(M,HasIsInvertible) then
         SetIsInvertible(a,ForAll(M,IsInvertible));
     fi;
-    SET_NAME@(M,"#",a);
+    Fr.SET_NAME(M,"#",a);
     return a;
 end);
 
 InstallMethod(DirectSumOp, "(FR) for generic FR machines",
         [IsList,IsFRMachine],
         function(M,N)
-    M := List(M,ASINTREP@);
+    M := List(M,Fr.ASINTREP);
     return DirectSumOp(M,M[1]);
 end);
 
@@ -1737,7 +1737,7 @@ InstallMethod(DirectProductOp, "(FR) for two Mealy machines",
     if ForAll(M,HasIsInvertible) then
         SetIsInvertible(a,ForAll(M,IsInvertible));
     fi;
-    SET_NAME@(M,"@",a);
+    Fr.SET_NAME(M,"@",a);
     return a;
 end);
 
@@ -1771,14 +1771,14 @@ InstallMethod(DirectProductOp, "(FR) for two integer Mealy machines",
     if ForAll(M,HasIsInvertible) then
         SetIsInvertible(a,ForAll(M,IsInvertible));
     fi;
-    SET_NAME@(M,"@",a);
+    Fr.SET_NAME(M,"@",a);
     return a;
 end);
 
 InstallMethod(DirectProductOp, "(FR) for generic FR machines",
         [IsList,IsFRMachine],
         function(M,N)
-    M := List(M,ASINTREP@);
+    M := List(M,Fr.ASINTREP);
     return DirectProductOp(M,M[1]);
 end);
 
@@ -1820,7 +1820,7 @@ InstallMethod(TreeWreathProduct, "(FR) for two domain Mealy machines",
     if HasIsInvertible(g) and HasIsInvertible(h) then
         SetIsInvertible(m,IsInvertible(g) and IsInvertible(h));
     fi;
-    SET_NAME@([g,h],"~",m);
+    Fr.SET_NAME([g,h],"~",m);
     return m;
 end);
 
@@ -1892,14 +1892,14 @@ InstallMethod(TreeWreathProduct, "(FR) for two integer Mealy machines",
     if HasIsInvertible(g) and HasIsInvertible(h) then
         SetIsInvertible(m,IsInvertible(g) and IsInvertible(h));
     fi;
-    SET_NAME@([g,h],"~",m);
+    Fr.SET_NAME([g,h],"~",m);
     return m;
 end);
 
 InstallMethod(TreeWreathProduct, "for two generic FR machines",
         [IsFRMachine, IsFRMachine, IsObject, IsObject],
         function(g,h,x0,y0)
-    return TreeWreathProduct(ASINTREP@(g),ASINTREP@(h),x0,y0);
+    return TreeWreathProduct(Fr.ASINTREP(g),Fr.ASINTREP(h),x0,y0);
     # !!! probably x0, y0 should be changed to their int counterparts?
 end);
 ############################################################################
@@ -1924,7 +1924,7 @@ InstallMethod(\*, "(FR) for two Mealy elements", IsIdenticalObj,
     if HasIsInvertible(M) and HasIsInvertible(N) then
         SetIsInvertible(a,IsInvertible(M) and IsInvertible(N));
     fi;
-    SET_NAME@([M,N],"*",a);
+    Fr.SET_NAME([M,N],"*",a);
     return a;
 end);
 
@@ -1957,7 +1957,7 @@ InstallMethod(\*, "(FR) for two Mealy elements", IsIdenticalObj,
         Add(trans,tr);
         Add(out,N!.output[i[2]]{M!.output[i[1]]});
     od;
-    a := MMMINIMIZE@(FamilyObj(M),AlphabetOfFRObject(M),
+    a := Fr.MMMINIMIZE(FamilyObj(M),AlphabetOfFRObject(M),
                  Length(trans),trans,out,1,1);
     if HasIsInvertible(M) and HasIsInvertible(N) then
         SetIsInvertible(a,IsInvertible(M) and IsInvertible(N));
@@ -2020,11 +2020,11 @@ end);
 ##
 InstallMethod(IsInvertible, "(FR) for a Mealy machine",
         [IsMealyMachine and IsMealyMachineIntRep],
-        M->ForAll(StateSet(M),i->ISINVERTIBLE@(M!.output[i])));
+        M->ForAll(StateSet(M),i->Fr.ISINVERTIBLE(M!.output[i])));
 
 InstallMethod(IsInvertible, "(FR) for a Mealy element",
         [IsMealyElement and IsMealyMachineIntRep],
-        M->ForAll(StateSet(M),i->ISINVERTIBLE@(M!.output[i])));
+        M->ForAll(StateSet(M),i->Fr.ISINVERTIBLE(M!.output[i])));
 
 InstallMethod(IsGeneratorsOfMagmaWithInverses, "(FR) for a list of Mealy elements",
         [IsFRElementCollection],
@@ -2038,7 +2038,7 @@ InstallMethod(IsGeneratorsOfMagmaWithInverses, "(FR) for a list of Mealy element
     return true;
 end);
 
-BindGlobal("SETINVERSENAME@", function(M,N)
+Fr.SETINVERSENAME := ( function(M,N)
     local n;
     if HasName(N) then
         n := Name(N);
@@ -2058,13 +2058,13 @@ InstallMethod(InverseOp, "(FR) for a Mealy machine",
     if not IsInvertible(M) then return fail; fi;
     if HasOrder(M) and Order(M) = 2 then return M; fi;
 
-    out := List(M!.output,INVERSE@);
+    out := List(M!.output,Fr.INVERSE);
     s := MealyMachineNC(FamilyObj(M),
                  List([1..M!.nrstates], i->M!.transitions[i]{out[i]}),
                  out);
     SetInverse(M,s); SetInverse(s,M);
     if HasOrder(M) then SetOrder(s,Order(M)); fi;
-    SETINVERSENAME@(s,M);
+    Fr.SETINVERSENAME(s,M);
     return s;
 end);
 
@@ -2075,15 +2075,15 @@ InstallMethod(InverseOp, "(FR) for a Mealy element",
     if not IsInvertible(E) then return fail; fi;
     if HasOrder(E) and Order(E) = 2 then return E; fi;
 
-    out := List(E!.output,INVERSE@);
-    s := MMMINIMIZE@(FamilyObj(E),AlphabetOfFRObject(E),
+    out := List(E!.output,Fr.INVERSE);
+    s := Fr.MMMINIMIZE(FamilyObj(E),AlphabetOfFRObject(E),
                  E!.nrstates,
                  List([1..E!.nrstates],i->E!.transitions[i]{out[i]}),
                  out,
                  E!.initial,2);
     SetInverse(E,s); SetInverse(s,E);
     if HasOrder(E) then SetOrder(s,Order(E)); fi;
-    SETINVERSENAME@(s,E);
+    Fr.SETINVERSENAME(s,E);
     return s;
 end);
 
@@ -2126,7 +2126,7 @@ end);
 #P  IsReversible
 #P  IsBireversible
 ##
-BindGlobal("ALPHABETINVOLUTION@", function(N)
+Fr.ALPHABETINVOLUTION := ( function(N)
     local l;
     l := List(StateSet(N),x->FRElement(N,x));
     l := List(l,x->Position(l,x^-1));
@@ -2142,7 +2142,7 @@ InstallMethod(DualMachine, "(FR) for a Mealy machine in int rep",
                  TransposedMat(M!.output),
                  TransposedMat(M!.transitions));
     if HasAlphabetInvolution(M) then
-        l := ALPHABETINVOLUTION@(M);
+        l := Fr.ALPHABETINVOLUTION(M);
         if l<>fail then
             SetAlphabetInvolution(N,l);
         fi;
@@ -2181,13 +2181,13 @@ InstallMethod(AlphabetInvolution, "(FR) for a bireversible Mealy machine",
     if not IsBireversible(M) then
         return fail;
     fi;
-    return ALPHABETINVOLUTION@(DualMachine(M));
+    return Fr.ALPHABETINVOLUTION(DualMachine(M));
 end);
 
 InstallMethod(IsMinimized, "(FR) for a Mealy machine",
         [IsMealyMachine and IsMealyMachineIntRep],
         function(M)
-    return MMMINIMIZE@(FamilyObj(M),AlphabetOfFRObject(M),
+    return Fr.MMMINIMIZE(FamilyObj(M),AlphabetOfFRObject(M),
         M!.nrstates,M!.transitions,M!.output,fail,0)!.nrstates=M!.nrstates;
 end);
 
@@ -2198,7 +2198,7 @@ InstallTrueMethod(IsMinimized, IsMealyElement and IsMealyMachineIntRep);
 ##
 #M  StateGrowth
 ##
-BindGlobal("STATEGROWTH@", function(M,z)
+Fr.STATEGROWTH := ( function(M,z)
     local src, mat, dest, s, a, is, it, enum;
     src := [];
     enum := Enumerator(StateSet(M));
@@ -2222,24 +2222,24 @@ end);
 
 InstallMethod(StateGrowth, "(FR) for a Mealy machine and an indeterminate",
         [IsMealyMachine, IsRingElement],
-        STATEGROWTH@);
+        Fr.STATEGROWTH);
 
 InstallMethod(StateGrowth, "(FR) for a Mealy element and an indeterminate",
         [IsMealyElement, IsRingElement],
-        STATEGROWTH@);
+        Fr.STATEGROWTH);
 
 InstallMethod(StateGrowth, "(FR) for a FR machine and an indeterminate",
         [IsFRMachine, IsRingElement],
         function(M,z)
     Info(InfoFR, 1, "StateGrowth: converting to Mealy machine");
-    return StateGrowth(ASINTREP@(M),z);
+    return StateGrowth(Fr.ASINTREP(M),z);
 end);
 
 InstallMethod(StateGrowth, "(FR) for a FR element and an indeterminate",
         [IsFRElement, IsRingElement],
         function(M,z)
     Info(InfoFR, 1, "StateGrowth: converting to Mealy element");
-    return StateGrowth(ASINTREP@(M),z);
+    return StateGrowth(Fr.ASINTREP(M),z);
 end);
 
 InstallMethod(StateGrowth, "(FR) for a FR object",
@@ -2248,7 +2248,7 @@ InstallMethod(StateGrowth, "(FR) for a FR object",
     return StateGrowth(M,Indeterminate(Rationals));
 end);
 
-BindGlobal("DEGREE_MEALYME@", function(M)
+Fr.DEGREE_MEALYME := ( function(M)
     local d, e, f, i, j, k, fM;
     M := Minimized(M);
     if IsOne(M) then return -1; fi;
@@ -2258,7 +2258,7 @@ BindGlobal("DEGREE_MEALYME@", function(M)
     for i in e do
         if Size(i)=1 then
             j := Representative(i);
-            if ISONE@(M!.output[j]) and
+            if Fr.ISONE(M!.output[j]) and
                ForAll(M!.transitions[j],k->k=j) then
                 continue; # is identity element
             fi;
@@ -2289,26 +2289,26 @@ BindGlobal("DEGREE_MEALYME@", function(M)
 end);
 InstallMethod(DegreeOfFRMachine, "(FR) for a Mealy machine",
         [IsMealyMachine and IsMealyMachineIntRep],
-        DEGREE_MEALYME@);
+        Fr.DEGREE_MEALYME);
 InstallMethod(DegreeOfFRMachine, "(FR) for an FR machine",
         [IsFRMachine],
         function(M)
     Info(InfoFR, 1, "Degree: converting to Mealy machine");
-    return DEGREE_MEALYME@(ASINTREP@(M));
+    return Fr.DEGREE_MEALYME(Fr.ASINTREP(M));
 end);
 InstallMethod(DegreeOfFRElement, "(FR) for a Mealy element",
         [IsMealyElement and IsMealyMachineIntRep],
-        DEGREE_MEALYME@);
+        Fr.DEGREE_MEALYME);
 InstallMethod(DegreeOfFRElement, "(FR) for an FR element",
         [IsFRElement],
         function(E)
     Info(InfoFR, 1, "Degree: converting to Mealy element");
-    return DEGREE_MEALYME@(ASINTREP@(E));
+    return Fr.DEGREE_MEALYME(Fr.ASINTREP(E));
 end);
 InstallMethod(Degree, [IsFRMachine], DegreeOfFRMachine);
 InstallMethod(Degree, [IsFRElement], DegreeOfFRElement);
 
-BindGlobal("DEPTH_MEALYME@", function(M)
+Fr.DEPTH_MEALYME := ( function(M)
     local i, j, f, fM, one, d, todo;
     if IsOne(M) then return 0; fi;
     M := Minimized(M);
@@ -2337,21 +2337,21 @@ BindGlobal("DEPTH_MEALYME@", function(M)
 end);
 InstallMethod(DepthOfFRMachine, "(FR) for a Mealy machine",
         [IsMealyMachine and IsMealyMachineIntRep],
-        DEPTH_MEALYME@);
+        Fr.DEPTH_MEALYME);
 InstallMethod(DepthOfFRMachine, "(FR) for an FR machine",
         [IsFRMachine],
         function(M)
     Info(InfoFR, 1, "Depth: converting to Mealy machine");
-    return DEPTH_MEALYME@(ASINTREP@(M));
+    return Fr.DEPTH_MEALYME(Fr.ASINTREP(M));
 end);
 InstallMethod(DepthOfFRElement, "(FR) for a Mealy element",
         [IsMealyElement and IsMealyMachineIntRep],
-        DEPTH_MEALYME@);
+        Fr.DEPTH_MEALYME);
 InstallMethod(DepthOfFRElement, "(FR) for an FR element",
         [IsFRElement],
         function(E)
     Info(InfoFR, 1, "Depth: converting to Mealy element");
-    return DEPTH_MEALYME@(ASINTREP@(E));
+    return Fr.DEPTH_MEALYME(Fr.ASINTREP(E));
 end);
 InstallMethod(Depth, [IsFRMachine], DepthOfFRMachine);
 InstallMethod(Depth, [IsFRElement], DepthOfFRElement);
@@ -2391,7 +2391,7 @@ InstallTrueMethod(IsFiniteStateFRMachine, IsPolynomialGrowthFRMachine);
 ##
 #M  Guess Mealy machine
 ##
-BindGlobal("SHRINKPERM@", function(perm,d,n)
+Fr.SHRINKPERM := ( function(perm,d,n)
     local l, m;
 
     l := ListTransformation(perm,d^n);
@@ -2407,7 +2407,7 @@ BindGlobal("SHRINKPERM@", function(perm,d,n)
     fi;
 end);
 
-BindGlobal("DECOMPPERM@", function(perm,d,n)
+Fr.DECOMPPERM := ( function(perm,d,n)
     local l, m, i, trans, out;
 
     l := ListTransformation(perm,d^n);
@@ -2435,7 +2435,7 @@ InstallOtherMethod(GuessMealyElement, "(FR) for a perm/trans, degree and depth",
     s := [];
     for i in [n,n-1..1] do
         s[i] := [perm];
-        perm := SHRINKPERM@(perm,d,i);
+        perm := Fr.SHRINKPERM(perm,d,i);
     od;
     i := 1;
     while i<=Length(level) do
@@ -2443,7 +2443,7 @@ InstallOtherMethod(GuessMealyElement, "(FR) for a perm/trans, degree and depth",
             return fail; # refuse to guess
         fi;
         Add(trans,[]);
-        dec := DECOMPPERM@(s[level[i]][i],d,level[i]);
+        dec := Fr.DECOMPPERM(s[level[i]][i],d,level[i]);
         Add(out,dec[2]);
         for j in [1..d] do
             x := Position(s[level[i]-1],dec[1][j]);
@@ -2452,7 +2452,7 @@ InstallOtherMethod(GuessMealyElement, "(FR) for a perm/trans, degree and depth",
                 Add(level,level[i]-1);
                 for k in [level[i]-1,level[i]-2..1] do
                     Add(s[k],dec[1][j]);
-                    dec[1][j] := SHRINKPERM@(dec[1][j],d,k);
+                    dec[1][j] := Fr.SHRINKPERM(dec[1][j],d,k);
                 od;
                 x := Length(level);
             elif Position(s[level[i]-1],dec[1][j],x)<>fail then
@@ -2476,7 +2476,7 @@ InstallMethod(Signatures, "(FR) for a Mealy element",
     local mat, dest, a, s, t, maker;
     mat := 0*IdentityMat(E!.nrstates);
     dest := [];
-    if ForAll(E!.output,ISINVERTIBLE@) then
+    if ForAll(E!.output,Fr.ISINVERTIBLE) then
         maker := PermList;
     else
         maker := TransformationList;
@@ -2496,14 +2496,14 @@ InstallMethod(Signatures, "(FR) for a Mealy element",
                    List(a,v->v[Position(StateSet(E),InitialState(E))]),
                    Position(a,dest));
 end);
-INSTALLMEHANDLER@(Signatures,true);
+Fr.INSTALLMEHANDLER(Signatures,true);
 
 InstallMethod(VertexTransformationsFRMachine, "(FR) for an FR machine",
         [IsFRMachine],
         function(M)
     local t;
     t := List(GeneratorsOfFRMachine(M),s->Output(M,s));
-    if ForAll(t,ISINVERTIBLE@) then
+    if ForAll(t,Fr.ISINVERTIBLE) then
         return Group(List(t,PermList));
     else
         return Monoid(List(t,TransformationList));
@@ -2633,11 +2633,11 @@ InstallGlobalFunction(AllMealyMachines,
             list := true;
         fi;
         F := List(Orbits(SymmetricGroup(2),F,function(ML,g)
-            if IsOne(g) or not ForAll(ML,M->ForAll(M[2],ISINVERTIBLE@)) then
+            if IsOne(g) or not ForAll(ML,M->ForAll(M[2],Fr.ISINVERTIBLE)) then
                 return ML;
             else
                 return Set(ML,M->[List([1..Length(M[1])],i->M[1][i]{M[2][i]}),
-                               List(M[2],INVERSE@)]);
+                               List(M[2],Fr.INVERSE)]);
             fi;
         end),Representative);
     fi;
@@ -2692,7 +2692,7 @@ InstallMethod(ConfinalityClasses, "(FR) for a Mealy element",
     one := EquivalenceRelationByPairs(one,classes);
     return EquivalenceClasses(one);
 end);
-INSTALLMEHANDLER@(ConfinalityClasses,true);
+Fr.INSTALLMEHANDLER(ConfinalityClasses,true);
 
 InstallMethod(Germs, "(FR) for a Mealy element",
         [IsMealyElement],
@@ -2723,7 +2723,7 @@ InstallMethod(Germs, "(FR) for a Mealy element",
     recur(InitialState(E));
     return classes;
 end);
-INSTALLMEHANDLER@(Germs,true);
+Fr.INSTALLMEHANDLER(Germs,true);
 
 InstallMethod(NormOfBoundedFRElement, "(FR) for a Mealy element",
         [IsMealyElement],
@@ -2752,7 +2752,7 @@ InstallMethod(NormOfBoundedFRElement, "(FR) for a Mealy element",
     states := [];
     return recur(InitialState(E));
 end);
-INSTALLMEHANDLER@(NormOfBoundedFRElement,true);
+Fr.INSTALLMEHANDLER(NormOfBoundedFRElement,true);
 
 InstallMethod(HasOpenSetConditionFRElement, "(FR) for a Mealy element",
         [IsMealyElement],
@@ -2766,7 +2766,7 @@ InstallMethod(HasOpenSetConditionFRElement, "(FR) for a Mealy element",
     od;
     return true;
 end);
-INSTALLMEHANDLER@(HasOpenSetConditionFRElement,true);
+Fr.INSTALLMEHANDLER(HasOpenSetConditionFRElement,true);
 
 InstallMethod(IsWeaklyFinitaryFRElement, "(FR) for a Mealy element",
         [IsMealyElement],
@@ -2775,7 +2775,7 @@ InstallMethod(IsWeaklyFinitaryFRElement, "(FR) for a Mealy element",
     c := ConfinalityClasses(E);
     return c<>fail and c=[];
 end);
-INSTALLMEHANDLER@(IsWeaklyFinitaryFRElement,true);
+Fr.INSTALLMEHANDLER(IsWeaklyFinitaryFRElement,true);
 #############################################################################
 
 #############################################################################
@@ -2787,12 +2787,12 @@ InstallMethod(LimitFRMachine, "(FR) for a Mealy machine",
         [IsMealyMachine and IsMealyMachineIntRep],
         function(M)
     local S, pos, i;
-    S := MEALYLIMITSTATES@(M);
+    S := Fr.MEALYLIMITSTATES(M);
     pos := [];
     pos{S} := [1..Length(S)];
     return MealyMachineNC(FamilyObj(M),List(M!.transitions{S},r->List(r,i->pos[i])),M!.output{S});
 end);
-INSTALLMMHANDLER@(LimitFRMachine,true);
+Fr.INSTALLMMHANDLER(LimitFRMachine,true);
 
 InstallMethod(NucleusMachine, "(FR) for an FR machine",
         [IsFRMachine],

--- a/gap/perlist.gi
+++ b/gap/perlist.gi
@@ -11,7 +11,7 @@
 ##
 #############################################################################
 ##
-BindGlobal("EXTENDPERIODICLIST@", function(l,i)
+Fr.EXTENDPERIODICLIST := ( function(l,i)
     local x;
     if l![2]=[] then return fail; fi;
     while Length(l![1])<i-Length(l![2]) do
@@ -123,8 +123,8 @@ InstallMethod(String, "for a periodic list",
         [IsPeriodicList],
         function(l)
     local s;
-    s := CONCAT@("PeriodicList(",l![1]);
-    if l![2]<>[] then APPEND@(s,",",l![2]); fi;
+    s := Fr.CONCAT("PeriodicList(",l![1]);
+    if l![2]<>[] then Fr.APPEND(s,",",l![2]); fi;
     Append(s,")");
     return s;
 end);
@@ -149,7 +149,7 @@ InstallMethod(ViewString, "for a periodic list",
     fi;
 end);
 
-INSTALLPRINTERS@(IsPeriodicList);
+Fr.INSTALLPRINTERS(IsPeriodicList);
 
 InstallMethod(ViewObj, "for a periodic list",
         [IsPeriodicList],
@@ -253,7 +253,7 @@ InstallMethod(ShallowCopy, "for a periodic list",
 InstallOtherMethod(\[\]\:\=, "for a periodic list, a position and an object",
         [IsPeriodicList,IsPosInt,IsObject],
         function(l,i,x)
-    EXTENDPERIODICLIST@(l,i);
+    Fr.EXTENDPERIODICLIST(l,i);
     l![1][i] := x;
 end);
 
@@ -262,7 +262,7 @@ InstallOtherMethod(\{\}\:\=, "for a periodic list, positions and objects",
         function(l,p,x)
     local i;
     for i in [1..Length(p)] do
-        EXTENDPERIODICLIST@(l,p[i]);
+        Fr.EXTENDPERIODICLIST(l,p[i]);
         l![1][p[i]] := x[i];
     od;
 end);
@@ -280,7 +280,7 @@ end);
 InstallOtherMethod(UNB_LIST, "for a periodic list and position",
         [IsPeriodicList, IsPosInt],
         function(l,i)
-    EXTENDPERIODICLIST@(l,i+1);
+    Fr.EXTENDPERIODICLIST(l,i+1);
     UNB_LIST(l![1],i);
 end);
 
@@ -297,7 +297,7 @@ end);
 InstallOtherMethod(Add, "for a periodic list, an element and a position",
         [IsPeriodicList, IsObject, IsPosInt],
         function(l,x,i)
-    EXTENDPERIODICLIST@(l,i-1);
+    Fr.EXTENDPERIODICLIST(l,i-1);
     Add(l![1],x,i);
 end);
 
@@ -314,7 +314,7 @@ end);
 InstallOtherMethod(Remove, "for a periodic list and a position",
         [IsPeriodicList, IsPosInt],
         function(l,i)
-    EXTENDPERIODICLIST@(l,i);
+    Fr.EXTENDPERIODICLIST(l,i);
     return Remove(l![1],i);
 end);
 
@@ -566,7 +566,7 @@ end);
 InstallMethod(Permuted, "for a periodic list",
         [IsPeriodicList,IsPerm],
         function(l,p)
-    EXTENDPERIODICLIST@(l,LargestMovedPoint(p));
+    Fr.EXTENDPERIODICLIST(l,LargestMovedPoint(p));
     return PeriodicList(Permuted(l![1],p),l![2]);
 end);
 
@@ -737,9 +737,9 @@ InstallMethod(String, "(FR) for a FIFO",
 
 InstallMethod(ViewString, "(FR) for a FIFO",
         [IsFIFO],
-        f->CONCAT@("<FIFO iterator of size ",Length(f),">"));
+        f->Fr.CONCAT("<FIFO iterator of size ",Length(f),">"));
 
-INSTALLPRINTERS@(IsFIFO);
+Fr.INSTALLPRINTERS(IsFIFO);
 
 InstallMethod(Length, "(FR) for a FIFO",
         [IsFIFO],
@@ -841,7 +841,7 @@ InstallOtherMethod(PositionProperty, "(FR) for a FIFO and a function",
         function(iter,f)
     return PositionProperty(iter,f,0);
 end);
-  
+
 InstallMethod(ForAllOp, "for a FIFO",
         [IsFIFO,IsFunction],
         function(l,p)

--- a/gap/vector.gi
+++ b/gap/vector.gi
@@ -13,7 +13,7 @@
 #############################################################################
 
 # Jacobian family
-BindGlobal("FRJFAMILY@",
+Fr.FRJFAMILY := (
         function(fam)
     local i, f;
     if IsListOrCollection(fam) then
@@ -53,7 +53,7 @@ InstallMethod(FREFamily, "(FR) for a jacobian linear element",
     od;
     return FREFamily(AlphabetOfFRObject(E));
 end);
-       
+
 ############################################################################
 ##
 #M  Minimized . . . . . . . . . . . . . . . . . . . .minimize linear machine
@@ -63,19 +63,19 @@ end);
 # mode=2 means all states are known to be distinct and accessible
 # boolean corr=true means compute correspondence
 ##
-BindGlobal("MATRIX@", function(l,f)
+Fr.MATRIX := ( function(l,f)
     return List(l,__x->List(__x,f));
 end);
 
-BindGlobal("VECTORZEROM@", function(f,n,r)
-    return VectorMachineNC(f,MATRIX@(IdentityMat(n),x->IdentityMat(0,r)),IdentityMat(0,r));
+Fr.VECTORZEROM := ( function(f,n,r)
+    return VectorMachineNC(f,Fr.MATRIX(IdentityMat(n),x->IdentityMat(0,r)),IdentityMat(0,r));
 end);
 
-BindGlobal("VECTORZEROE@", function(f,n,r)
-    return VectorElementNC(f,MATRIX@(IdentityMat(n),x->IdentityMat(0,r)),IdentityMat(0,r),IdentityMat(0,r));
+Fr.VECTORZEROE := ( function(f,n,r)
+    return VectorElementNC(f,Fr.MATRIX(IdentityMat(n),x->IdentityMat(0,r)),IdentityMat(0,r),IdentityMat(0,r));
 end);
 
-BindGlobal("COEFF@", function(B,v)
+Fr.COEFF := ( function(B,v)
     local x;
     x := Coefficients(B,v);
     ConvertToVectorRep(x);
@@ -83,14 +83,14 @@ BindGlobal("COEFF@", function(B,v)
     return x;
 end);
 
-BindGlobal("CONSTANTVECTOR@", function(S,x)
+Fr.CONSTANTVECTOR := ( function(S,x)
     local v;
     v := ListWithIdenticalEntries(Length(S),x);
     ConvertToVectorRep(v);
     return v;
 end);
 
-BindGlobal("VECTORMINIMIZE@", function(fam,r,transitions,output,input,mode,docorr)
+Fr.VECTORMINIMIZE := ( function(fam,r,transitions,output,input,mode,docorr)
     local B, i, n, v, V, W, t, m, todo, f, corr;
 
     if input<>fail then ConvertToVectorRep(input); fi;
@@ -115,13 +115,13 @@ BindGlobal("VECTORMINIMIZE@", function(fam,r,transitions,output,input,mode,docor
         od;
         if Dimension(V)<Length(input) then
             B := Basis(V);
-            input := COEFF@(B,input);
+            input := Fr.COEFF(B,input);
             v := transitions;
             transitions := [];
             for i in v do
                 t := [];
                 for i in i do
-                    m := List(B,x->COEFF@(B,x*i));
+                    m := List(B,x->Fr.COEFF(B,x*i));
                     MakeImmutable(m);
                     ConvertToMatrixRep(m);
                     Add(t,m);
@@ -129,7 +129,7 @@ BindGlobal("VECTORMINIMIZE@", function(fam,r,transitions,output,input,mode,docor
                 Add(transitions,t);
             od;
             if docorr then
-                corr := List(corr,v->COEFF@(B,v));
+                corr := List(corr,v->Fr.COEFF(B,v));
                 MakeImmutable(corr);
                 ConvertToMatrixRep(corr);
                 Error("cannot happen");
@@ -145,9 +145,9 @@ BindGlobal("VECTORMINIMIZE@", function(fam,r,transitions,output,input,mode,docor
     fi;
     if Length(output)=0 or IsZero(output) then
         if input=fail then
-            f := VECTORZEROM@(fam,Length(transitions),r);
+            f := Fr.VECTORZEROM(fam,Length(transitions),r);
         else
-            f := VECTORZEROE@(fam,Length(transitions),r);
+            f := Fr.VECTORZEROE(fam,Length(transitions),r);
         fi;
         if docorr then SetCorrespondence(f,[]); fi;
         return f;
@@ -172,14 +172,14 @@ BindGlobal("VECTORMINIMIZE@", function(fam,r,transitions,output,input,mode,docor
             W := List(B,x->PreImagesRepresentativeNC(f,x));
             ConvertToMatrixRep(W);
             if input <> fail then
-                input := COEFF@(B,input^f);
+                input := Fr.COEFF(B,input^f);
             fi;
             v := transitions;
             transitions := [];
             for i in v do
                 t := [];
                 for i in i do
-                    m := List(W,x->COEFF@(B,(x*i)^f));
+                    m := List(W,x->Fr.COEFF(B,(x*i)^f));
                     MakeImmutable(m);
                     ConvertToMatrixRep(m);
                     Add(t,m);
@@ -187,7 +187,7 @@ BindGlobal("VECTORMINIMIZE@", function(fam,r,transitions,output,input,mode,docor
                 Add(transitions,t);
             od;
             if docorr then
-                corr := List(corr,v->COEFF@(B,v^f));
+                corr := List(corr,v->Fr.COEFF(B,v^f));
                 MakeImmutable(corr);
                 ConvertToMatrixRep(corr);
             fi;
@@ -215,13 +215,13 @@ BindGlobal("VECTORMINIMIZE@", function(fam,r,transitions,output,input,mode,docor
         od;
         if todo<>IdentityMat(Length(output),r) then
             B := BasisNC(V,todo);
-            input := COEFF@(B,input);
+            input := Fr.COEFF(B,input);
             v := transitions;
             transitions := [];
             for i in v do
                 t := [];
                 for i in i do
-                    m := List(B,x->COEFF@(B,x*i));
+                    m := List(B,x->Fr.COEFF(B,x*i));
                     MakeImmutable(m);
                     ConvertToMatrixRep(m);
                     Add(t,m);
@@ -229,7 +229,7 @@ BindGlobal("VECTORMINIMIZE@", function(fam,r,transitions,output,input,mode,docor
                 Add(transitions,t);
             od;
             if docorr then
-                corr := List(corr,v->COEFF@(B,v));
+                corr := List(corr,v->Fr.COEFF(B,v));
                 MakeImmutable(corr);
                 ConvertToMatrixRep(corr);
             fi;
@@ -247,12 +247,12 @@ end);
 
 InstallMethod(Minimized, "(FR) for a vector machine",
         [IsLinearFRMachine and IsVectorFRMachineRep],
-        M->VECTORMINIMIZE@(FamilyObj(M),LeftActingDomain(M),
+        M->Fr.VECTORMINIMIZE(FamilyObj(M),LeftActingDomain(M),
                 M!.transitions,M!.output,fail,0,true));
 
 InstallMethod(Minimized, "(FR) for a vector element",
         [IsLinearFRElement and IsVectorFRMachineRep],
-        E->VECTORMINIMIZE@(FamilyObj(E),LeftActingDomain(E),
+        E->Fr.VECTORMINIMIZE(FamilyObj(E),LeftActingDomain(E),
                 E!.transitions,E!.output,E!.input,0,true));
 
 InstallMethod(IsMinimized, "(FR) for a vector machine",
@@ -335,7 +335,7 @@ end);
 InstallOtherMethod(\[\], "(FR) for a vector element and an index",
         [IsLinearFRElement and IsVectorFRMachineRep,IsPosInt],
         function(E,i)
-    return List(E!.transitions[i],v->VECTORMINIMIZE@(FamilyObj(E),LeftActingDomain(E),E!.transitions,E!.output,E!.input*v,0,false));
+    return List(E!.transitions[i],v->Fr.VECTORMINIMIZE(FamilyObj(E),LeftActingDomain(E),E!.transitions,E!.output,E!.input*v,0,false));
 end);
 
 InstallMethod(Transition, "(FR) for a vector element",
@@ -359,7 +359,7 @@ InstallMethod(GeneratorsOfFRMachine, "(FR) for a vector machine",
 InstallOtherMethod(\^, "(FR) for a vector and a vector element",
         [IsVector, IsLinearFRElement and IsVectorFRMachineRep],
         function(v,e)
-    return v*MATRIX@(e!.transitions,v->e!.input*v*e!.output);
+    return v*Fr.MATRIX(e!.transitions,v->e!.input*v*e!.output);
 end);
 
 InstallMethod(Activity, "(FR) for a vector element and a level",
@@ -377,11 +377,11 @@ InstallMethod(Activity, "(FR) for a vector element and a level",
         ConvertToMatrixRep(m);
         return m;
     fi;
-    m := MATRIX@(e!.transitions, function(v)
+    m := Fr.MATRIX(e!.transitions, function(v)
         v := [e!.input*v]; ConvertToMatrixRep(v); return v;
     end);
     for i in [2..n] do m := KroneckerProduct(m,e!.transitions,2); od;
-    m := MATRIX@(m,v->v[1]*e!.output);
+    m := Fr.MATRIX(m,v->v[1]*e!.output);
     b := ValueOption("blocks");
     if b=fail then
         ConvertToMatrixRep(m);
@@ -406,7 +406,7 @@ InstallMethod(Activities, "(FR) for a vector element and a level",
     m := e!.transitions;
     b := ValueOption("blocks");
     for i in [2..n] do
-        r := MATRIX@(m,v->e!.input*v*e!.output);
+        r := Fr.MATRIX(m,v->e!.input*v*e!.output);
         if b=fail then
             ConvertToMatrixRep(r);
         else
@@ -421,8 +421,8 @@ InstallMethod(Activities, "(FR) for a vector element and a level",
     return result;
 end);
 
-ACTIVITYSPARSE@ := fail; # shut up warning
-ACTIVITYSPARSE@ := function(l,e,v,n,x,y)
+Fr.ACTIVITYSPARSE := fail; # shut up warning
+Fr.ACTIVITYSPARSE := function(l,e,v,n,x,y)
     local d, p, i, j;
     if IsZero(v) then return; fi;
     if n=0 then
@@ -438,25 +438,24 @@ ACTIVITYSPARSE@ := function(l,e,v,n,x,y)
     else
         d := Length(e!.transitions);
         for i in [1..d] do for j in [1..d] do
-            ACTIVITYSPARSE@(l,e,v*e!.transitions[i][j],n-1,(x-1)*d+i,(y-1)*d+j);
+            Fr.ACTIVITYSPARSE(l,e,v*e!.transitions[i][j],n-1,(x-1)*d+i,(y-1)*d+j);
         od; od;
     fi;
 end;
-MakeReadOnlyGlobal("ACTIVITYSPARSE@");
 
 InstallMethod(ActivitySparse, "(FR) for a vector element and a level",
         [IsLinearFRElement and IsVectorFRMachineRep, IsInt],
         function(e,n)
     local l;
     l := [];
-    ACTIVITYSPARSE@(l,e,e!.input,n,1,1);
+    Fr.ACTIVITYSPARSE(l,e,e!.input,n,1,1);
     return l;
 end);
 
 InstallOtherMethod(State, "(FR) for a vector element and two vectors",
         [IsLinearFRElement and IsVectorFRMachineRep, IsVector, IsVector],
         function(E,a,b)
-    return VECTORMINIMIZE@(FamilyObj(E),LeftActingDomain(E),E!.transitions,E!.output,E!.input*(a*E!.transitions*b),0,false);
+    return Fr.VECTORMINIMIZE(FamilyObj(E),LeftActingDomain(E),E!.transitions,E!.output,E!.input*(a*E!.transitions*b),0,false);
 end);
 
 InstallOtherMethod(NestedMatrixState, "(FR) for a vector element and two lists",
@@ -467,7 +466,7 @@ InstallOtherMethod(NestedMatrixState, "(FR) for a vector element and two lists",
     for n in [1..Length(ilist)] do
         x := x*E!.transitions[ilist[n]][jlist[n]];
     od;
-    return VECTORMINIMIZE@(FamilyObj(E),LeftActingDomain(E),E!.transitions,E!.output,x,0,false);
+    return Fr.VECTORMINIMIZE(FamilyObj(E),LeftActingDomain(E),E!.transitions,E!.output,x,0,false);
 end);
 
 InstallOtherMethod(NestedMatrixCoefficient, "(FR) for a vector element and two lists",
@@ -484,7 +483,7 @@ end);
 InstallMethod(DecompositionOfFRElement, "(FR) for a vector element",
         [IsLinearFRElement and IsVectorFRMachineRep],
         function(E)
-    return MATRIX@(E!.transitions,v->VECTORMINIMIZE@(FamilyObj(E),LeftActingDomain(E),E!.transitions,E!.output,E!.input*v,0,false));
+    return Fr.MATRIX(E!.transitions,v->Fr.VECTORMINIMIZE(FamilyObj(E),LeftActingDomain(E),E!.transitions,E!.output,E!.input*v,0,false));
 end);
 
 InstallMethod(DecompositionOfFRElement, "(FR) for a vector element and a level",
@@ -517,7 +516,7 @@ InstallOtherMethod(States, "(FR) for a vector machine",
         M->VectorSpace(LeftActingDomain(M),
                 List(Basis(StateSet(M)),s->FRElement(M,s))));
 
-BindGlobal("DECOMPMATRIX@", function(m,d,n)
+Fr.DECOMPMATRIX := ( function(m,d,n)
     local result, N, i, j, k;
     result := List([1..d],i->List([1..d],j->[]));
     for k in [2..n] do
@@ -531,13 +530,13 @@ BindGlobal("DECOMPMATRIX@", function(m,d,n)
     return result;
 end);
 
-BindGlobal("GUESSMATRIX@", function(r,matlist,d)
+Fr.GUESSMATRIX := ( function(r,matlist,d)
     local spaces, bases, trans, inp, out, i, ii, j, jj, k, m, n, todo, c, x;
 
     n := Length(matlist);
     if n<=1 then return fail; fi;
     if IsZero(matlist[n]) then
-        return VECTORZEROE@(FREFamily(r^d),d,r);
+        return Fr.VECTORZEROE(FREFamily(r^d),d,r);
     fi;
     spaces := [];
     bases := [];
@@ -558,7 +557,7 @@ BindGlobal("GUESSMATRIX@", function(r,matlist,d)
             Add(inp,Zero(r));
         fi;
         n := Length(m)-1;
-        m := DECOMPMATRIX@(m,d,n+1);
+        m := Fr.DECOMPMATRIX(m,d,n+1);
         if spaces[n]=fail then return fail; fi;
         for i in [1..d] do
             for j in [1..d] do
@@ -630,17 +629,17 @@ InstallGlobalFunction(GuessVectorElement, # "(FR) for a matrix[list], ring, degr
     if not IsBound(r) then
         r := FieldOfMatrixList(matlist);
     fi;
-    return GUESSMATRIX@(r,matlist,d);
+    return Fr.GUESSMATRIX(r,matlist,d);
 end);
 
 InstallMethod(TransposedFRElement, "(FR) for a vector element",
         [IsLinearFRElement and IsVectorFRMachineRep],
         function(E)
-    return VECTORMINIMIZE@(FamilyObj(E),LeftActingDomain(E),
+    return Fr.VECTORMINIMIZE(FamilyObj(E),LeftActingDomain(E),
                    TransposedMat(E!.transitions),E!.output,E!.input,2,false);
 end);
 
-BindGlobal("ISTRIANGULARVECTOR@", function(e,prop)
+Fr.ISTRIANGULARVECTOR := ( function(e,prop)
     local V, x, n, v, w, i, j, todo;
     V := TrivialSubspace(StateSet(e));
     n := Length(e!.transitions);
@@ -675,15 +674,15 @@ InstallMethod(IsAntisymmetricFRElement, "(FR) for a linear element",
 
 InstallMethod(IsLowerTriangularFRElement, "(FR) for a vector element",
         [IsLinearFRElement and IsVectorFRMachineRep],
-        E->ISTRIANGULARVECTOR@(E,IsLowerTriangularFRElement));
+        E->Fr.ISTRIANGULARVECTOR(E,IsLowerTriangularFRElement));
 
 InstallMethod(IsUpperTriangularFRElement, "(FR) for a vector element",
         [IsLinearFRElement and IsVectorFRMachineRep],
-        E->ISTRIANGULARVECTOR@(E,IsUpperTriangularFRElement));
+        E->Fr.ISTRIANGULARVECTOR(E,IsUpperTriangularFRElement));
 
 InstallMethod(IsDiagonalFRElement, "(FR) for a vector element",
         [IsLinearFRElement and IsVectorFRMachineRep],
-        E->ISTRIANGULARVECTOR@(E,IsDiagonalFRElement));
+        E->Fr.ISTRIANGULARVECTOR(E,IsDiagonalFRElement));
 
 InstallMethod(LDUDecompositionFRElement, "(FR) for an FR element",
         [IsLinearFRElement],
@@ -722,7 +721,7 @@ end);
 #O  VectorMachine
 #O  VectorElement
 ##
-BindGlobal("VECTORCHECK@", function(transitions,output,input)
+Fr.VECTORCHECK := ( function(transitions,output,input)
     local m, n, i, j;
     if input<>fail then
         MakeImmutable(input);
@@ -762,7 +761,7 @@ end);
 InstallMethod(VectorMachine, "(FR) for lists of transitions and output",
         [IsRing,IsTransitionTensor,IsVector],
         function(r,transitions,output)
-    VECTORCHECK@(transitions,output,fail);
+    Fr.VECTORCHECK(transitions,output,fail);
     return VectorMachineNC(FRMFamily(r^Length(transitions)),
                    One(r)*transitions,One(r)*output);
 end);
@@ -787,8 +786,8 @@ end);
 InstallMethod(VectorElement, "(FR) for lists of transitions, output and input",
         [IsRing,IsTransitionTensor,IsVector,IsVector],
         function(r,transitions,output,input)
-    VECTORCHECK@(transitions,output,input);
-    return VECTORMINIMIZE@(FREFamily(r^Length(transitions)),r,
+    Fr.VECTORCHECK(transitions,output,input);
+    return Fr.VECTORMINIMIZE(FREFamily(r^Length(transitions)),r,
                    One(r)*transitions,One(r)*output,One(r)*input,0,false);
 end);
 
@@ -796,19 +795,19 @@ InstallMethod(VectorElement, "(FR) for lists of transitions, output and input, n
         [IsRing,IsTransitionTensor,IsVector,IsVector,IsOperation],
         function(r,transitions,output,input,cat)
     local fam;
-    VECTORCHECK@(transitions,output,input);
+    Fr.VECTORCHECK(transitions,output,input);
     if cat=IsJacobianElement then
-        fam := FRJFAMILY@(r^Length(transitions));
+        fam := Fr.FRJFAMILY(r^Length(transitions));
     else
         fam := FREFamily(r^Length(transitions));
     fi;
-    return VECTORMINIMIZE@(fam,r,One(r)*transitions,One(r)*output,One(r)*input,0,false);
+    return Fr.VECTORMINIMIZE(fam,r,One(r)*transitions,One(r)*output,One(r)*input,0,false);
 end);
 
 InstallMethod(FRElement, "(FR) for a vector machine and a state",
         [IsLinearFRMachine and IsVectorFRMachineRep, IsVector],
         function(M,s)
-    return VECTORMINIMIZE@(FREFamily(M),LeftActingDomain(M),M!.transitions,M!.output,s,0,false);
+    return Fr.VECTORMINIMIZE(FREFamily(M),LeftActingDomain(M),M!.transitions,M!.output,s,0,false);
 end);
 
 InstallMethod(FRElement, "(FR) for a vector machine, a state and a category",
@@ -816,40 +815,40 @@ InstallMethod(FRElement, "(FR) for a vector machine, a state and a category",
         function(M,s,cat)
     local f;
     if cat=IsJacobianElement then
-        f := FRJFAMILY@(M);
+        f := Fr.FRJFAMILY(M);
     else
         f := FREFamily(M);
     fi;
-    return VECTORMINIMIZE@(f,LeftActingDomain(M),M!.transitions,M!.output,s,0,false);
+    return Fr.VECTORMINIMIZE(f,LeftActingDomain(M),M!.transitions,M!.output,s,0,false);
 end);
 
 InstallMethod(FRElement, "(FR) for a vector element and a state",
         [IsLinearFRElement and IsVectorFRMachineRep, IsVector],
         function(E,s)
-    return VECTORMINIMIZE@(FamilyObj(E),LeftActingDomain(E),E!.transitions,E!.output,s,2,false);
+    return Fr.VECTORMINIMIZE(FamilyObj(E),LeftActingDomain(E),E!.transitions,E!.output,s,2,false);
 end);
 
 InstallMethod(FRElement, "(FR) for a vector machine and a state index",
         [IsLinearFRMachine and IsVectorFRMachineRep, IsInt],
         function(M,s)
     if IsZero(M) then
-        return VECTORZEROE@(FREFamily(M),Dimension(AlphabetOfFRObject(M)),LeftActingDomain(M));
+        return Fr.VECTORZEROE(FREFamily(M),Dimension(AlphabetOfFRObject(M)),LeftActingDomain(M));
     fi;
-    return VECTORMINIMIZE@(FREFamily(M),LeftActingDomain(M),M!.transitions,M!.output,\[\](M!.transitions[1][1]^0,s),0,false);
+    return Fr.VECTORMINIMIZE(FREFamily(M),LeftActingDomain(M),M!.transitions,M!.output,\[\](M!.transitions[1][1]^0,s),0,false);
 end);
 
 InstallMethod(FRElement, "(FR) for a vector element and a state index",
         [IsLinearFRElement and IsVectorFRMachineRep, IsInt],
         function(E,s)
     if IsZero(E) then
-        return VECTORZEROE@(FamilyObj(E),Dimension(AlphabetOfFRObject(E)),LeftActingDomain(E));
+        return Fr.VECTORZEROE(FamilyObj(E),Dimension(AlphabetOfFRObject(E)),LeftActingDomain(E));
     fi;
-    return VECTORMINIMIZE@(FamilyObj(E),LeftActingDomain(E),E!.transitions,E!.output,\[\](E!.transitions[1][1]^0,s),2,false);
+    return Fr.VECTORMINIMIZE(FamilyObj(E),LeftActingDomain(E),E!.transitions,E!.output,\[\](E!.transitions[1][1]^0,s),2,false);
 end);
 
 InstallMethod(LieObject, "(FR) for an associative vector element",
         [IsLinearFRElement and IsVectorFRMachineRep and IsAssociativeElement],
-        e->VectorElementNC(FRJFAMILY@(e),e!.transitions,e!.output,e!.input));
+        e->VectorElementNC(Fr.FRJFAMILY(e),e!.transitions,e!.output,e!.input));
 
 InstallMethod(AssociativeObject, "(FR) for a jacobian vector element",
         [IsLinearFRElement and IsVectorFRMachineRep and IsJacobianElement],
@@ -865,7 +864,7 @@ InstallMethod(AssociativeObject, "(FR) for a jacobian vector element",
 InstallMethod(ViewString, "(FR) for a vector machine",
         [IsLinearFRMachine and IsVectorFRMachineRep],
         function(M)
-    return CONCAT@("<Linear machine on alphabet ", LeftActingDomain(M), "^",
+    return Fr.CONCAT("<Linear machine on alphabet ", LeftActingDomain(M), "^",
                Length(M!.transitions), " with ", Length(M!.output), "-dimensional stateset>");
 end);
 
@@ -880,9 +879,9 @@ InstallMethod(ViewString, "(FR) for a vector element",
     else
         s := "<L"; skip := false;
     fi;
-    Append(s,CONCAT@("inear element on alphabet ",LeftActingDomain(E),"^", Length(E!.transitions)));
+    Append(s,Fr.CONCAT("inear element on alphabet ",LeftActingDomain(E),"^", Length(E!.transitions)));
     if not skip then
-        Append(s,CONCAT@(" with ",Length(E!.output), "-dimensional stateset"));
+        Append(s,Fr.CONCAT(" with ",Length(E!.output), "-dimensional stateset"));
     fi;
     if IsJacobianElement(E) then
         Append(s,"-");
@@ -894,7 +893,7 @@ end);
 InstallMethod(String, "(FR) vector machine to string",
         [IsLinearFRMachine and IsVectorFRMachineRep],
         function(M)
-    return CONCAT@("VectorMachine(",LeftActingDomain(M),", ", M!.transitions,", ", M!.output,")");
+    return Fr.CONCAT("VectorMachine(",LeftActingDomain(M),", ", M!.transitions,", ", M!.output,")");
 end);
 
 InstallMethod(String, "(FR) vector element to string",
@@ -906,11 +905,11 @@ InstallMethod(String, "(FR) vector element to string",
     else
         x := "";
     fi;
-    return CONCAT@("VectorElement(",LeftActingDomain(E),", ",
+    return Fr.CONCAT("VectorElement(",LeftActingDomain(E),", ",
                    E!.transitions,", ", E!.output,", ",E!.input,x,")");
 end);
 
-BindGlobal("VECTORDISPLAY@", function(M)
+Fr.VECTORDISPLAY := ( function(M)
     local r, i, j, k, l, m, n, xlen, xprint, xrule, headlen, headrule, headblank, s;
     r := LeftActingDomain(M);
     n := Length(M!.transitions);
@@ -929,63 +928,63 @@ BindGlobal("VECTORDISPLAY@", function(M)
 
     s := Concatenation(String(r,headlen)," |");
     for i in [1..n] do
-        APPEND@(s,String(i,QuoInt(xlen*m,2)+1),String("",xlen*m-QuoInt(xlen*m,2)),"|");
+        Fr.APPEND(s,String(i,QuoInt(xlen*m,2)+1),String("",xlen*m-QuoInt(xlen*m,2)),"|");
     od;
     Append(s,"\n");
-    APPEND@(s,headrule,"-+");
+    Fr.APPEND(s,headrule,"-+");
     for i in [1..n] do
         for j in [1..m] do Append(s,xrule); od;
         Append(s,"-+");
     od;
     Append(s,"\n");
     for i in [1..n] do
-        APPEND@(s,String(i,headlen)," ");
+        Fr.APPEND(s,String(i,headlen)," ");
         if m>=1 then
-            APPEND@(s,"|");
+            Fr.APPEND(s,"|");
             for j in [1..m] do
-                if j>1 then APPEND@(s,headblank," |"); fi;
+                if j>1 then Fr.APPEND(s,headblank," |"); fi;
                 for k in [1..n] do
                     for l in [1..m] do
-                        APPEND@(s," ",xprint(M!.transitions[i][k][j][l]));
+                        Fr.APPEND(s," ",xprint(M!.transitions[i][k][j][l]));
                     od;
-                    APPEND@(s," |");
+                    Fr.APPEND(s," |");
                 od;
-                APPEND@(s,"\n");
+                Fr.APPEND(s,"\n");
             od;
-            APPEND@(s,headrule,"-");
+            Fr.APPEND(s,headrule,"-");
         fi;
-        APPEND@(s,"+");
+        Fr.APPEND(s,"+");
         for i in [1..n] do
-            for j in [1..m] do APPEND@(s,xrule); od;
-            APPEND@(s,"-+");
+            for j in [1..m] do Fr.APPEND(s,xrule); od;
+            Fr.APPEND(s,"-+");
         od;
-        APPEND@(s,"\n");
+        Fr.APPEND(s,"\n");
     od;
-    APPEND@(s,"Output:");
+    Fr.APPEND(s,"Output:");
     for i in [1..m] do
-        APPEND@(s," ",xprint(M!.output[i]));
+        Fr.APPEND(s," ",xprint(M!.output[i]));
     od;
-    APPEND@(s,"\n");
+    Fr.APPEND(s,"\n");
     if IsLinearFRElement(M) then
         if IsJacobianElement(M) then
-            APPEND@(s,"Jacobian; ");
+            Fr.APPEND(s,"Jacobian; ");
         fi;
-        APPEND@(s,"Initial state:");
+        Fr.APPEND(s,"Initial state:");
         for i in [1..m] do
-            APPEND@(s," ",xprint(M!.input[i]));
+            Fr.APPEND(s," ",xprint(M!.input[i]));
         od;
-        APPEND@(s,"\n");
+        Fr.APPEND(s,"\n");
     fi;
     return s;
 end);
 
 InstallMethod(DisplayString, "(FR) for a vector machine",
         [IsLinearFRMachine and IsVectorFRMachineRep],
-        VECTORDISPLAY@);
+        Fr.VECTORDISPLAY);
 
 InstallMethod(DisplayString, "(FR) for a vector element",
         [IsLinearFRElement and IsVectorFRMachineRep],
-        VECTORDISPLAY@);
+        Fr.VECTORDISPLAY);
 #############################################################################
 
 #############################################################################
@@ -993,21 +992,21 @@ InstallMethod(DisplayString, "(FR) for a vector element",
 #M AsVectorMachine
 #M AsVectorElement
 ##
-BindGlobal("DELTA@", function(x) if x then return 1; else return 0; fi; end);
+Fr.DELTA := ( function(x) if x then return 1; else return 0; fi; end);
 
-BindGlobal("ASVECTORMACHINE@", function(r,M)
+Fr.ASVECTORMACHINE := ( function(r,M)
     local id, V;
     id := IdentityMat(Size(StateSet(M)),r);
     V := VectorMachineNC(FRMFamily(r^Size(AlphabetOfFRObject(M))),
-                 List(AlphabetOfFRObject(M),i->List(AlphabetOfFRObject(M),j->List(StateSet(M),s->DELTA@(Output(M,s,i)=j)*id[Transition(M,s,i)]))),
-                 CONSTANTVECTOR@(StateSet(M),One(r)));
+                 List(AlphabetOfFRObject(M),i->List(AlphabetOfFRObject(M),j->List(StateSet(M),s->Fr.DELTA(Output(M,s,i)=j)*id[Transition(M,s,i)]))),
+                 Fr.CONSTANTVECTOR(StateSet(M),One(r)));
     SetCorrespondence(V,id);
     return V;
 end);
 
 InstallMethod(AsVectorMachine, "(FR) for a Mealy machine",
         [IsRing,IsMealyMachine and IsMealyMachineIntRep],
-        ASVECTORMACHINE@);
+        Fr.ASVECTORMACHINE);
 
 InstallMethod(AsVectorMachine, "(FR) for a FR machine",
         [IsRing,IsFRMachine],
@@ -1015,7 +1014,7 @@ InstallMethod(AsVectorMachine, "(FR) for a FR machine",
     local N, V;
     Info(InfoFR,2,"AsVectorMachine: converting to Mealy machine");
     N := AsMealyMachine(M);
-    V := ASVECTORMACHINE@(r,N);
+    V := Fr.ASVECTORMACHINE(r,N);
     V!.Correspondence := Correspondence(V){Correspondence(N)};
     return V;
 end);
@@ -1035,32 +1034,32 @@ end);
 
 InstallMethod(AsLinearMachine, "(FR) for a Mealy machine",
         [IsRing,IsMealyMachine and IsMealyMachineIntRep],
-        ASVECTORMACHINE@);
+        Fr.ASVECTORMACHINE);
 
-BindGlobal("ASVECTORELEMENT@", function(r,E)
+Fr.ASVECTORELEMENT := ( function(r,E)
     local id, V;
     id := IdentityMat(Size(StateSet(E)),r);
-    V := VECTORMINIMIZE@(FREFamily(r^Size(AlphabetOfFRObject(E))),r,
-                 List(AlphabetOfFRObject(E),i->List(AlphabetOfFRObject(E),j->List(StateSet(E),s->DELTA@(Output(E,s,i)=j)*id[Transition(E,s,i)]))),
-                 CONSTANTVECTOR@(StateSet(E),One(r)),
+    V := Fr.VECTORMINIMIZE(FREFamily(r^Size(AlphabetOfFRObject(E))),r,
+                 List(AlphabetOfFRObject(E),i->List(AlphabetOfFRObject(E),j->List(StateSet(E),s->Fr.DELTA(Output(E,s,i)=j)*id[Transition(E,s,i)]))),
+                 Fr.CONSTANTVECTOR(StateSet(E),One(r)),
                  IdentityMat(Size(StateSet(E)),r)[1],0,true);
     return V;
 end);
 
 InstallMethod(AsVectorElement, "(FR) for a Mealy element",
         [IsRing,IsMealyElement and IsMealyMachineIntRep],
-        ASVECTORELEMENT@);
+        Fr.ASVECTORELEMENT);
 
 InstallMethod(AsVectorElement, "(FR) for a FR element",
         [IsRing,IsFRElement],
         function(r,E)
     Info(InfoFR,2,"AsVectorMachine: converting to Mealy machine");
-    return ASVECTORELEMENT@(r,AsMealyElement(E));
+    return Fr.ASVECTORELEMENT(r,AsMealyElement(E));
 end);
 
 InstallMethod(AsLinearElement, "(FR) for a Mealy element",
         [IsRing,IsMealyElement and IsMealyMachineIntRep],
-        ASVECTORELEMENT@);
+        Fr.ASVECTORELEMENT);
 
 InstallMethod(AsMealyElement, "(FR) for a vector element",
         [IsLinearFRElement and IsVectorFRMachineRep],
@@ -1101,10 +1100,10 @@ InstallMethod(TopElement, "(FR) for a ring and a matrix",
         function(r,m)
     if IsOne(m) then
         return VectorElementNC(FREFamily(r^Length(m)),
-                       One(r)*MATRIX@(m,x->[[x]]),[One(r)],[One(r)]);
+                       One(r)*Fr.MATRIX(m,x->[[x]]),[One(r)],[One(r)]);
     else
         return VectorElementNC(FREFamily(r^Length(m)),
-                       One(r)*(MATRIX@(m,x->[[0,x],[0,0]])+MATRIX@(m^0,x->[[0,0],[0,x]])),
+                       One(r)*(Fr.MATRIX(m,x->[[0,x],[0,0]])+Fr.MATRIX(m^0,x->[[0,0],[0,x]])),
             [One(r),One(r)],[One(r),Zero(r)]);
     fi;
 end);
@@ -1140,7 +1139,7 @@ InstallMethod(OneOp, "(FR) for a vector machine",
         [IsLinearFRMachine and IsVectorFRMachineRep],
         function(M)
     return VectorMachineNC(FamilyObj(M),
-                   MATRIX@(IdentityMat(Length(M!.transitions),LeftActingDomain(M)),x->[[x]]),
+                   Fr.MATRIX(IdentityMat(Length(M!.transitions),LeftActingDomain(M)),x->[[x]]),
                    [One(LeftActingDomain(M))]);
 end);
 
@@ -1148,22 +1147,22 @@ InstallMethod(OneOp, "(FR) for a vector element",
         [IsLinearFRElement and IsVectorFRMachineRep],
         function(E)
     return VectorElementNC(FamilyObj(E),
-                   MATRIX@(IdentityMat(Length(E!.transitions),LeftActingDomain(E)),x->[[x]]),
+                   Fr.MATRIX(IdentityMat(Length(E!.transitions),LeftActingDomain(E)),x->[[x]]),
                    [One(LeftActingDomain(E))],
                    [One(LeftActingDomain(E))]);
 end);
 
 InstallMethod(ZeroOp, "(FR) for a vector machine",
         [IsLinearFRMachine and IsVectorFRMachineRep],
-        M->VECTORZEROM@(FamilyObj(M),Length(M!.transitions),
+        M->Fr.VECTORZEROM(FamilyObj(M),Length(M!.transitions),
                 LeftActingDomain(M)));
 
 InstallMethod(ZeroOp, "(FR) for a vector element",
         [IsLinearFRElement and IsVectorFRMachineRep],
-        E->VECTORZEROE@(FamilyObj(E),Length(E!.transitions),
+        E->Fr.VECTORZEROE(FamilyObj(E),Length(E!.transitions),
                 LeftActingDomain(E)));
 
-BindGlobal("VECTORPLUS@", function(M,N)
+Fr.VECTORPLUS := ( function(M,N)
     local i, j, t, x, zM, zN, transitions, output, input;
 
     if IsZero(M) then return N; fi;
@@ -1190,7 +1189,7 @@ BindGlobal("VECTORPLUS@", function(M,N)
         input := Concatenation(M!.input,N!.input);
         MakeImmutable(input);
         ConvertToVectorRepNC(input);
-        return VECTORMINIMIZE@(FamilyObj(M),LeftActingDomain(M),
+        return Fr.VECTORMINIMIZE(FamilyObj(M),LeftActingDomain(M),
                        transitions,output,input,0,false);
     else
         return VectorMachineNC(FamilyObj(M),transitions,output);
@@ -1200,12 +1199,12 @@ end);
 InstallMethod(\+, "for two vector machines", IsIdenticalObj,
         [IsLinearFRMachine and IsVectorFRMachineRep,
          IsLinearFRMachine and IsVectorFRMachineRep],
-        VECTORPLUS@);
+        Fr.VECTORPLUS);
 
 InstallMethod(\+, "for two vector elements", IsIdenticalObj,
         [IsLinearFRElement and IsVectorFRMachineRep,
          IsLinearFRElement and IsVectorFRMachineRep],
-        VECTORPLUS@);
+        Fr.VECTORPLUS);
 
 InstallMethod(\*, "for a scalar and a vector machine",
         [IsScalar,IsLinearFRMachine and IsVectorFRMachineRep],
@@ -1247,7 +1246,7 @@ InstallMethod(AdditiveInverseSameMutability, "for a vector element",
     return VectorElementNC(FamilyObj(E),E!.transitions,-E!.output,E!.input);
 end);
 
-BindGlobal("VECTORTIMES@", function(M,N)
+Fr.VECTORTIMES := ( function(M,N)
     local i, j, k, t, x, transitions, output, input;
 
     if Length(M!.output)=0 or Length(N!.output)=0 then
@@ -1268,7 +1267,7 @@ BindGlobal("VECTORTIMES@", function(M,N)
         input := KroneckerProduct(M!.input,N!.input,1);
         MakeImmutable(input);
         ConvertToVectorRepNC(input);
-        x := VECTORMINIMIZE@(FamilyObj(M),LeftActingDomain(M),
+        x := Fr.VECTORMINIMIZE(FamilyObj(M),LeftActingDomain(M),
                        transitions,output,input,0,false);
     else
         x := VectorMachineNC(FamilyObj(M),transitions,output);
@@ -1279,18 +1278,18 @@ end);
 InstallMethod(\*, "for two vector machines", IsIdenticalObj,
         [IsLinearFRMachine and IsVectorFRMachineRep,
          IsLinearFRMachine and IsVectorFRMachineRep],
-        VECTORTIMES@);
+        Fr.VECTORTIMES);
 
 InstallMethod(\*, "for two vector elements", IsIdenticalObj,
         [IsLinearFRElement and IsVectorFRMachineRep and IsAssociativeElement,
          IsLinearFRElement and IsVectorFRMachineRep and IsAssociativeElement],
-        VECTORTIMES@);
+        Fr.VECTORTIMES);
 
 InstallMethod(\*, "for two vector elements", IsIdenticalObj,
         [IsLinearFRElement and IsVectorFRMachineRep and IsJacobianElement,
          IsLinearFRElement and IsVectorFRMachineRep and IsJacobianElement],
         function(x,y)
-    return VECTORTIMES@(x,y)-VECTORTIMES@(y,x);
+    return Fr.VECTORTIMES(x,y)-Fr.VECTORTIMES(y,x);
 end);
 
 InstallMethod(PthPowerImage, "for a vector element",
@@ -1301,7 +1300,7 @@ InstallMethod(PthPowerImage, "for a vector element",
     if not IsPrime(p) then TryNextMethod(); fi;
     return LieObject(AssociativeObject(x)^p);
 end);
-           
+
 InstallMethod(PthPowerImage, "for a vector element and a number",
         [IsLinearFRElement and IsVectorFRMachineRep and IsJacobianElement, IsInt],
         function(x,n)
@@ -1310,12 +1309,12 @@ InstallMethod(PthPowerImage, "for a vector element and a number",
     if not IsPrime(p) then TryNextMethod(); fi;
     return LieObject(AssociativeObject(x)^(p^n));
 end);
-           
+
 InstallMethod(\*, "for a scalar and a vector element",
         [IsScalar,IsLinearFRElement and IsVectorFRMachineRep],
         function(x,E)
     if not IsRat(x) and not x in LeftActingDomain(E) then TryNextMethod(); fi; # matrix?
-    return VECTORMINIMIZE@(FamilyObj(E),LeftActingDomain(E),
+    return Fr.VECTORMINIMIZE(FamilyObj(E),LeftActingDomain(E),
                    E!.transitions,x*E!.output,E!.input,1,false);
 end);
 
@@ -1323,7 +1322,7 @@ InstallMethod(\*, "for a vector element and a scalar",
         [IsLinearFRElement and IsVectorFRMachineRep,IsScalar],
         function(E,x)
     if not IsRat(x) and not x in LeftActingDomain(E) then TryNextMethod(); fi; # matrix?
-    return VECTORMINIMIZE@(FamilyObj(E),LeftActingDomain(E),
+    return Fr.VECTORMINIMIZE(FamilyObj(E),LeftActingDomain(E),
                    E!.transitions,E!.output*x,E!.input,1,false);
 end);
 
@@ -1449,9 +1448,9 @@ end);
 #!!! take limit states of vector machine
 #!!! multiply vector machine with generating machine
 #!!! minimize
-BindGlobal("VECTORLIMITMACHINE@", function(M)
+Fr.VECTORLIMITMACHINE := ( function(M)
     local V, W, i, j;
-    
+
     W := StateSet(M);
     repeat
         V := W;
@@ -1462,12 +1461,12 @@ BindGlobal("VECTORLIMITMACHINE@", function(M)
             od; od;
         od;
     until V=W;
-    return VectorMachineNC(FamilyObj(M),MATRIX@(M!.transitions,x->List(Basis(W),b->Coefficients(Basis(W),b*x))),Basis(W)*M!.output);
+    return VectorMachineNC(FamilyObj(M),Fr.MATRIX(M!.transitions,x->List(Basis(W),b->Coefficients(Basis(W),b*x))),Basis(W)*M!.output);
 end);
 
-BindGlobal("LINEARLIMITSTATES@", function(L)
+Fr.LINEARLIMITSTATES := ( function(L)
     local V, B, d, W, oldW, r;
-#!!!    V := LINEARSTATES@(L);
+#!!!    V := Fr.LINEARSTATES(L);
     B := Basis(V);
     d := TransposedMat(List(B,w->List(Concatenation(DecompositionOfFRElement(w)),x->Coefficients(B,x))));
     W := LeftActingDomain(V)^Length(B);
@@ -1480,17 +1479,17 @@ end);
 
 InstallMethod(LimitStates, "(FR) for a linear element",
         [IsLinearFRElement and IsFRElementStdRep],
-        x->LINEARLIMITSTATES@([x]));
+        x->Fr.LINEARLIMITSTATES([x]));
 #!!! disable / integrate in code. We need to keep track of the linear elements
 #with their natural machine rep
 
 InstallMethod(LimitStates, "(FR) for a vector machine",
         [IsLinearFRMachine and IsVectorFRMachineRep],
-        M->States(VECTORLIMITMACHINE@(M)));
+        M->States(Fr.VECTORLIMITMACHINE(M)));
 
 InstallMethod(LimitStates, "(FR) for a vector element",
         [IsLinearFRElement and IsVectorFRMachineRep],
-        E->States(VECTORLIMITMACHINE@(E)));
+        E->States(Fr.VECTORLIMITMACHINE(E)));
 
 InstallMethod(LimitStates, "(FR) for a space of linear elements",
         [IsFRElementCollection],
@@ -1504,16 +1503,16 @@ end);
 
 InstallMethod(LimitFRMachine, "(FR) for a vector machine",
         [IsLinearFRMachine and IsVectorFRMachineRep],
-        VECTORLIMITMACHINE@);
+        Fr.VECTORLIMITMACHINE);
 
 InstallMethod(LimitFRMachine, "(FR) for a vector element",
         [IsLinearFRElement and IsVectorFRMachineRep],
-        VECTORLIMITMACHINE@);
+        Fr.VECTORLIMITMACHINE);
 
 InstallMethod(LimitFRMachine, "(FR) for a space of linear elements",
         [IsVectorSpace and IsFRElementCollection],
         function(V)
-    return VECTORLIMITMACHINE@(Sum(GeneratorsOfVectorSpace(V),x->AsVectorMachine(UnderlyingFRMachine(x))));
+    return Fr.VECTORLIMITMACHINE(Sum(GeneratorsOfVectorSpace(V),x->AsVectorMachine(UnderlyingFRMachine(x))));
 end);
 
 InstallMethod(LimitFRMachine, "(FR) for a space of linear elements",
@@ -1522,10 +1521,10 @@ InstallMethod(LimitFRMachine, "(FR) for a space of linear elements",
     if not ForAll(L,IsLinearFRElement) then
         TryNextMethod();
     fi;
-    return VECTORLIMITMACHINE@(Sum(L,x->AsVectorMachine(UnderlyingFRMachine(x))));
+    return Fr.VECTORLIMITMACHINE(Sum(L,x->AsVectorMachine(UnderlyingFRMachine(x))));
 end);
 
-BindGlobal("LINEARNUCLEUS@", function(V)
+Fr.LINEARNUCLEUS := ( function(V)
     # V is a vector space of linear elements, e.g. state space of a machine
     local v, newv, oldv, x, gens;
     gens := Basis(V);
@@ -1546,7 +1545,7 @@ BindGlobal("LINEARNUCLEUS@", function(V)
         fi;
     od;
     return v;
-end);    
+end);
 #!!! disable
 
 InstallMethod(NucleusOfFRMachine, "(FR) for a linear machine",
@@ -1557,9 +1556,9 @@ InstallMethod(NucleusMachine, "(FR) for a linear machine",
         [IsLinearFRMachine],
         function(M)
     local l, oldl;
-    
+
     #!!! keep track of original generators, if they're linear elements
-    
+
     M := LimitFRMachine(Minimized(AsVectorMachine(M)));
     l := M;
     repeat
@@ -1595,7 +1594,7 @@ end,
     fi;
     m := Minimized(Sum(List(b,UnderlyingFRMachine)));
     init := List([1..Length(b)],i->Concatenation(List([1..Length(b)],
-                 j->DELTA@(i=j)*AsList(b[j]!.input))));
+                 j->Fr.DELTA(i=j)*AsList(b[j]!.input))));
     # need "AsList" because NullMapMatrix is not a list :(
 
     return rec(machine := m,

--- a/gap/vhgroup.gi
+++ b/gap/vhgroup.gi
@@ -22,7 +22,7 @@ end);
 ##
 #M VHStructure
 ##
-BindGlobal("VHSTRUCTURE@", function(result,r,v,h)
+Fr.VHSTRUCTURE := ( function(result,r,v,h)
     local i, m, n, getv, geth, addrel;
 
     m := Length(v);
@@ -90,7 +90,7 @@ InstallMethod(VHStructure, "for a f.p. group",
     if Intersection(v,h)<>[] then TryNextMethod(); fi;
     result := rec(v := GeneratorsOfGroup(G){v},
                   h := GeneratorsOfGroup(G){h});
-    if VHSTRUCTURE@(result,r,v,h)=fail then
+    if Fr.VHSTRUCTURE(result,r,v,h)=fail then
         TryNextMethod();
     fi;
     SetVHStructure(FamilyObj(One(G)),result);
@@ -106,7 +106,7 @@ InstallMethod(ViewString, "for a VH group",
     t := String(VHStructure(G).h);
     return Concatenation("<VH group on the generators ",s{[1..Length(s)-1]},"|",t{[2..Length(t)]},">");
 end);
-INSTALLPRINTERS@(IsVHGroup);
+Fr.INSTALLPRINTERS(IsVHGroup);
 
 InstallMethod(FpElementNFFunction, "for a VH group",
         [IsElementOfFpGroupFamily and HasVHStructure],
@@ -117,9 +117,9 @@ InstallMethod(FpElementNFFunction, "for a VH group",
     gffam := FamilyObj(UnderlyingElement(Representative(CollectionsFamily(gfam)!.wholeGroup)));
     vgens := [];
     for i in r.v do Add(vgens,String(i)); od;
-    for i in Reversed(r.v) do Add(vgens,CONCAT@(i,"^-1")); od;
+    for i in Reversed(r.v) do Add(vgens,Fr.CONCAT(i,"^-1")); od;
     for i in r.h do Add(vgens,String(i)); od;
-    for i in Reversed(r.h) do Add(vgens,CONCAT@(i,"^-1")); od;
+    for i in Reversed(r.h) do Add(vgens,Fr.CONCAT(i,"^-1")); od;
     mon := FreeMonoid(vgens);
     mffam := FamilyObj(Representative(mon));
     m := Length(r.v);
@@ -283,15 +283,15 @@ InstallGlobalFunction(VHGroup, function(arg)
     if Length(l)<>m*n or ForAny(l,x->0 in x) then
         Error("Missing corners ",Difference(Cartesian(Concatenation([-m..-1],[1..m]),Concatenation([-n..-1],[1..n])),r));
     fi;
-    v := List([1..m],i->CONCAT@("a",i));
-    h := List([1..n],i->CONCAT@("b",i));
+    v := List([1..m],i->Fr.CONCAT("a",i));
+    h := List([1..n],i->Fr.CONCAT("b",i));
     f := FreeGroup(Concatenation(v,h));
     v := GeneratorsOfGroup(f){[1..m]};
     h := GeneratorsOfGroup(f){[m+1..m+n]};
     f := f / List(l,x->v[AbsInt(x[1])]^SignInt(x[1])*h[AbsInt(x[2])]^SignInt(x[2])*v[AbsInt(x[3])]^SignInt(x[3])*h[AbsInt(x[4])]^SignInt(x[4]));
     i := rec(v := GeneratorsOfGroup(f){[1..m]},
              h := GeneratorsOfGroup(f){[m+1..m+n]});
-    VHSTRUCTURE@(i,l,[1..m],[1..n]);
+    Fr.VHSTRUCTURE(i,l,[1..m],[1..n]);
     SetVHStructure(f,i);
     SetVHStructure(FamilyObj(One(f)),i);
     SetReducedMultiplication(f);
@@ -331,7 +331,7 @@ InstallMethod(IsIrreducibleVHGroup, "(FR) for a VH group",
         TryNextMethod();
     fi;
     for q in act do
-        if not IsPGroup(EDGESTABILIZER@(q)) then return true; fi;
+        if not IsPGroup(Fr.EDGESTABILIZER(q)) then return true; fi;
     od;
     if ForAny(act,IsFinite) then return false; fi;
     TryNextMethod();
@@ -428,13 +428,13 @@ InstallMethod(IsInfinitelyTransitive, "(FR) for an FR group",
     if not HasUnderlyingFRMachine(G) then TryNextMethod(); fi;
     M := UnderlyingFRMachine(G);
     if not IsBireversible(M) then TryNextMethod(); fi;
-    
+
     # first see if the top group is 2-transitive, and has sufficient
     # transitivity in its 2-neighbourhood (see [Rattaggi, Prop. 1.2(3a)])
     if Transitivity(VertexTransformations(G),AlphabetOfFRSemigroup(G))>=2 and
        not IsSolvable(Stabilizer(VertexTransformations(G),1)) then
         Info(InfoFR,3, "IsInfinitelyTransitive: testing non-solvability of edge stabilizers");
-        return not IsSolvable(EDGESTABILIZER@(G));
+        return not IsSolvable(Fr.EDGESTABILIZER(G));
     fi;
     if not HasAlphabetInvolution(M) then
         return IsLevelTransitiveFRGroup(G);
@@ -450,7 +450,7 @@ InstallMethod(IsInfinitelyTransitive, "(FR) for an FR group",
     Error("Should not be reached!");
 end);
 
-BindGlobal("MEALY2WORD@", function(x,g,h)
+Fr.MEALY2WORD := ( function(x,g,h)
     local stack, seen, work, i, nx, nw, n, time;
     if IsOne(x) then
         return One(h[1]);
@@ -470,7 +470,7 @@ BindGlobal("MEALY2WORD@", function(x,g,h)
         work := Remove(First(stack,x->x<>[]));
         time := time+1;
         if time mod 1000 = 0 then
-            Info(InfoFR,1,"MEALY2WORD@: considering now a Mealy machine on ",work[1]!.nrstates, " states");
+            Info(InfoFR,1,"Fr.MEALY2WORD: considering now a Mealy machine on ",work[1]!.nrstates, " states");
         fi;
         AddDictionary(seen,work[1]);
         for i in [1..Length(g)] do
@@ -506,7 +506,7 @@ InstallMethod(IsomorphismFpGroup, "(FR) for an FR group",
         g := m{StateSet(m)};
         h := GeneratorsOfGroup(f);
         SortParallel(g,h);
-        return GroupHomomorphismByFunction(G,f,x->MEALY2WORD@(x,g,GeneratorsOfGroup(f)),w->MappedWord(w,GeneratorsOfGroup(f),g));
+        return GroupHomomorphismByFunction(G,f,x->Fr.MEALY2WORD(x,g,GeneratorsOfGroup(f)),w->MappedWord(w,GeneratorsOfGroup(f),g));
     fi;
     TryNextMethod();
 end);
@@ -517,11 +517,11 @@ end);
 #E GammaPQMachine
 #E GammaPQGroup
 ##
-BindGlobal("QUATERNIONBASIS@", fail); # must be computed only at run-time
+Fr.QUATERNIONBASIS := ( fail); # must be computed only at run-time
 
-BindGlobal("QUATERNIONNORMP@", function(p)
+Fr.QUATERNIONNORMP := ( function(p)
     local a, b, c, d, bound, result, x, y, z;
-    
+
     if not IsPrime(p) then
         Error("Argument ",p," should be prime");
     fi;
@@ -543,9 +543,9 @@ BindGlobal("QUATERNIONNORMP@", function(p)
                 if a^2+b^2+c^2>p then continue; fi;
                 d := RootInt(p-a^2-b^2-c^2);
                 if a^2+b^2+c^2+d^2=p then
-                    Add(result,[a,b,c,d]*QUATERNIONBASIS@);
+                    Add(result,[a,b,c,d]*Fr.QUATERNIONBASIS);
                     if d<>0 then
-                        Add(result,[a,b,c,-d]*QUATERNIONBASIS@);
+                        Add(result,[a,b,c,-d]*Fr.QUATERNIONBASIS);
                     fi;
                 fi;
             od;
@@ -556,28 +556,28 @@ end);
 
 #qconj := function(q)
 #    local c;
-#    c := Coefficients(QUATERNIONBASIS@,q);
-#    return [c[1],-c[2],-c[3],-c[4]]*QUATERNIONBASIS@;
+#    c := Coefficients(Fr.QUATERNIONBASIS,q);
+#    return [c[1],-c[2],-c[3],-c[4]]*Fr.QUATERNIONBASIS;
 #end;
 
 #qnorm := function(q)
-#    return Coefficients(QUATERNIONBASIS@,q)^2;
+#    return Coefficients(Fr.QUATERNIONBASIS,q)^2;
 #end;
 
-BindGlobal("QUATERNIONFACTOR@", function(q,l)
+Fr.QUATERNIONFACTOR := ( function(q,l)
     local result, i, j, p, qq;
     result := [];
     for i in l do
-        p := Coefficients(QUATERNIONBASIS@,i[1])^2;
+        p := Coefficients(Fr.QUATERNIONBASIS,i[1])^2;
         for j in [1..Length(i)] do
             qq := Inverse(i[j])*q;
-            if ForAll(Coefficients(QUATERNIONBASIS@,qq),IsInt) then
+            if ForAll(Coefficients(Fr.QUATERNIONBASIS,qq),IsInt) then
                 q := qq;
                 Add(result,j);
                 break;
             fi;
         od;
-        if not ForAll(Coefficients(QUATERNIONBASIS@,qq),IsInt) then
+        if not ForAll(Coefficients(Fr.QUATERNIONBASIS,qq),IsInt) then
             return fail;
         fi;
     od;
@@ -588,25 +588,23 @@ end);
 InstallGlobalFunction(GammaPQMachine, function(p,q)
     local i, j, k, pset, qset, trans, out;
 
-    if QUATERNIONBASIS@=fail then
-        MakeReadWriteGlobal("QUATERNIONBASIS@FR");
-        QUATERNIONBASIS@ := Basis(QuaternionAlgebra(Rationals));
-        MakeReadOnlyGlobal("QUATERNIONBASIS@FR");
+    if Fr.QUATERNIONBASIS=fail then
+        Fr.QUATERNIONBASIS := Basis(QuaternionAlgebra(Rationals));
     fi;
 
-    pset := QUATERNIONNORMP@(p);
-    qset := QUATERNIONNORMP@(q);
+    pset := Fr.QUATERNIONNORMP(p);
+    qset := Fr.QUATERNIONNORMP(q);
     trans := List(pset,x->[]);
     out := List(pset,x->[]);
     for i in [1..p+1] do
         for j in [1..q+1] do
-            k := QUATERNIONFACTOR@(pset[i]*qset[j],[qset,pset]);
+            k := Fr.QUATERNIONFACTOR(pset[i]*qset[j],[qset,pset]);
             out[i][k[1]] := j;
             trans[i][k[1]] := k[2];
         od;
     od;
     i := MealyMachine(trans,out);
-    SetName(i,CONCAT@("GammaPQMachine(",p,",",q,")"));
+    SetName(i,Fr.CONCAT("GammaPQMachine(",p,",",q,")"));
     SetCorrespondence(i,[pset,qset]);
     out := [];
     for j in qset do
@@ -767,7 +765,7 @@ BindGlobal("RattaggiGroup",
                    # CONJ 2.70: G0 is simple
                    2_70 := VHGroup([1,1,-1,-2],[1,2,-2,-1],[1,3,-2,1],
                            [1,-3,2,3],[1,-2,-2,-3],[2,1,-2,2]),
-                   
+
                    # PROP 3.27: (PGL(2,13),PGL(2,17)), virtually simplex
                    # if V=<1+2i+2j+2k,3+2i,1+4j,3+2i+2j>, then group is V/ZV
                    3_26 := VHGroup([1,1,3,3],[1,2,2,1],[1,3,4,2],

--- a/init.g
+++ b/init.g
@@ -10,18 +10,20 @@
 ##
 #############################################################################
 
-#I introducing globally the NC versions of PreImages...  
-if not IsBound( PreImagesNC ) then 
-    BindGlobal( "PreImagesNC", PreImages ); 
-fi; 
-if not IsBound( PreImagesRepresentativeNC ) then 
-    BindGlobal( "PreImagesRepresentativeNC", PreImagesRepresentative ); 
-fi; 
+#I introducing globally the NC versions of PreImages...
+if not IsBound( PreImagesNC ) then
+    BindGlobal( "PreImagesNC", PreImages );
+fi;
+if not IsBound( PreImagesRepresentativeNC ) then
+    BindGlobal( "PreImagesRepresentativeNC", PreImagesRepresentative );
+fi;
 
 #############################################################################
-POSTHOOK@fr := []; # to be processed at the end
+BindGlobal("Fr", rec());
 
-BindGlobal("@", rec()); # a record to store locals in the package
+Fr.POSTHOOK := []; # to be processed at the end
+
+Fr.locals := rec(); # a record to store locals in the package
 
 #############################################################################
 ##
@@ -47,12 +49,12 @@ ReadPackage("fr", "gap/bisets.gd");
 ReadPackage("fr", "gap/examples.gd");
 ReadPackage("fr", "gap/cp.gd");
 
-@.nql := IsBound(IsLpGroup);
+Fr.locals.nql := IsBound(IsLpGroup);
 
-if not @.nql then # shut up warnings in case LpGroups is not present
+if not Fr.locals.nql then # shut up warnings in case LpGroups is not present
     Perform(["IsLpGroup","IsElementOfLpGroup","LPresentedGroup",
             "ElementOfLpGroup","SetEmbeddingOfAscendingSubgroup"], function(w)
         BindGlobal(w, fail);
-        Add(POSTHOOK@fr,function() MakeReadWriteGlobal(w); UnbindGlobal(w); end);
+        Add(Fr.POSTHOOK,function() MakeReadWriteGlobal(w); UnbindGlobal(w); end);
     end);
 fi;

--- a/read.g
+++ b/read.g
@@ -66,7 +66,7 @@ end);
 ##
 #X install shortcuts
 ##
-INSTALL@ := function()
+Fr.INSTALL := function()
     CallFuncList(function(arg)
         local s;
         for s in arg do
@@ -116,9 +116,9 @@ DeclareAttribute("IsLevelTransitive", IsFRElement);
 DeclareAttribute("IsLevelTransitive", IsFRGroup);
 InstallMethod(IsLevelTransitive, [IsFRGroup], IsLevelTransitiveFRGroup);
 InstallMethod(IsLevelTransitive, [IsFRElement], IsLevelTransitiveFRElement);
-        
-while not IsEmpty(POSTHOOK@fr) do Remove(POSTHOOK@fr)(); od;
-Unbind(POSTHOOK@fr);
+
+while not IsEmpty(Fr.POSTHOOK) do Remove(Fr.POSTHOOK)(); od;
+Unbind(Fr.POSTHOOK);
 
 if IsBound(IO_Pickle) then
     ReadPackage("fr","gap/pickle.g");

--- a/tst/chapter-5-a.tst
+++ b/tst/chapter-5-a.tst
@@ -1371,7 +1371,7 @@ gap> Info(InfoFR,1,"4.2.4 Activity");
 #I  4.2.4 Activity
 gap> 
 gap> for i in [1,2,3,4,5, 7,8 ] do
->   Print(ForAll(mealyel[i]{[1,2,  5]}, el_list -> List(el_list, g -> ANY2OUT@FR(Activity(g, 1), Size(AlphabetOfFRObject(g)))) = outputsm[i]), "\n");
+>   Print(ForAll(mealyel[i]{[1,2,  5]}, el_list -> List(el_list, g -> Fr.ANY2OUT(Activity(g, 1), Size(AlphabetOfFRObject(g)))) = outputsm[i]), "\n");
 > od;
 true
 true


### PR DESCRIPTION
There is a plan that we might remove namespaces from GAP (code using '@'), because the implementation doesn't really work that well.

This PR is an experiment to see how Fr could be fixed, and how nice the code looks, without using '@'. I don't consider this PR a requirement to merge, and it might not even be the nicest way to do this! However, Fr is one of the biggest users of namespaces and '@'.

Similar to how I have handled similar issues in my own packages, I've added a global record 'Fr', and then put all the 'fr' methods inside that. The only place this doesn't work with with attributes / methods, so those I've prefixed with 'Fr_'.

One issue is we can't use 'BindGlobal' any more, so I just assign members of the record.